### PR TITLE
[feat]: 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/like/controller/UserLikeController.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/controller/UserLikeController.java
@@ -1,0 +1,24 @@
+package com.fifo.ticketing.domain.like.controller;
+
+import com.fifo.ticketing.domain.like.dto.LikeRequest;
+import com.fifo.ticketing.domain.like.service.LikeService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/like")
+public class UserLikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping
+    public ResponseEntity<String> toggleLike(@RequestBody LikeRequest likeRequest){
+        boolean liked = likeService.toggleLike(likeRequest);
+        return ResponseEntity.ok(liked ? "Liked" : "Unliked");
+    }
+
+}
+

--- a/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
@@ -2,16 +2,8 @@ package com.fifo.ticketing.domain.like.dto;
 
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class LikeRequest {
 
-    private Long userId;
-    private Long performanceId;
-
-}
+public record LikeRequest(Long userId, Long performanceId) {}

--- a/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
@@ -6,4 +6,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 
-public record LikeRequest(Long userId, Long performanceId) {}
+@Getter
+@AllArgsConstructor
+public class LikeRequest {
+
+    private final Long userId;
+    private final Long performanceId;
+
+}

--- a/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
@@ -1,0 +1,17 @@
+package com.fifo.ticketing.domain.like.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LikeRequest {
+
+    private Long userId;
+    private Long performanceId;
+
+}

--- a/src/main/java/com/fifo/ticketing/domain/like/entity/Like.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/entity/Like.java
@@ -5,14 +5,14 @@ import com.fifo.ticketing.domain.user.entity.User;
 import com.fifo.ticketing.global.entity.BaseDateEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "like")
+@Table(name = "likes")
 @NoArgsConstructor
-@AllArgsConstructor
 public class Like extends BaseDateEntity {
 
     @Id
@@ -26,4 +26,20 @@ public class Like extends BaseDateEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "performance_id", nullable = false, foreignKey = @ForeignKey(name = "fk_like_to_performance"))
     private Performance performance;
+
+    @Column(name = "is_liked")
+    private boolean isLiked;
+
+    @Builder
+    public Like(Long id, User user, Performance performance, boolean isLiked) {
+        this.id = id;
+        this.user = user;
+        this.performance = performance;
+        this.isLiked = isLiked;
+    }
+
+    //이것만 세터 가능하게
+    public void setLiked(boolean liked) {
+        this.isLiked = liked;
+    }
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/entity/Like.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/entity/Like.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @Table(name = "likes")
 @NoArgsConstructor
 public class Like extends BaseDateEntity {

--- a/src/main/java/com/fifo/ticketing/domain/like/entity/LikeCount.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/entity/LikeCount.java
@@ -4,11 +4,13 @@ import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.global.entity.BaseDateEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @Table(name = "like_count")
 @NoArgsConstructor
 @AllArgsConstructor
@@ -24,4 +26,9 @@ public class LikeCount extends BaseDateEntity {
 
     @Column(nullable = false)
     private Long likeCount;
+
+    public void setLikeCount(long likeCount) {
+        this.likeCount = likeCount;
+    }
+
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/repository/LikeCountRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/repository/LikeCountRepository.java
@@ -1,7 +1,11 @@
 package com.fifo.ticketing.domain.like.repository;
 
 import com.fifo.ticketing.domain.like.entity.LikeCount;
+import com.fifo.ticketing.domain.performance.entity.Performance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeCountRepository extends JpaRepository<LikeCount, Long> {
+    Optional<LikeCount> findByPerformance(Performance performance);
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/repository/LikeRepository.java
@@ -1,7 +1,12 @@
 package com.fifo.ticketing.domain.like.repository;
 
 import com.fifo.ticketing.domain.like.entity.Like;
+import com.fifo.ticketing.domain.performance.entity.Performance;
+import com.fifo.ticketing.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    Like findByUserAndPerformance(User user, Performance performance);
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
@@ -40,6 +40,7 @@ public class LikeService {
                     .isLiked(true)
                     .build();
             likeRepository.save(like);
+            updateLike(performance,1);
             // likecount 제거
             return true;
         }//없다ㅕㄴ
@@ -65,6 +66,7 @@ public class LikeService {
                 .orElseThrow(() -> new EntityNotFoundException("not found"));
 
         long updatedCnt = likeCount.getLikeCount() + cnt;
+        updatedCnt = Math.max(0, updatedCnt); //  음수 방지
         likeCount.setLikeCount(updatedCnt);
         likeCountRepository.save(likeCount);
 

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
@@ -16,7 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_MEMBER;
-import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCE;
+import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCES;
+
 
 
 @Service
@@ -35,7 +36,7 @@ public class LikeService {
                 .orElseThrow(() -> new ErrorException(NOT_FOUND_MEMBER));
 
         Performance performance = performanceRepository.findById(likeRequest.getPerformanceId())
-                .orElseThrow( ()-> new ErrorException(NOT_FOUND_PERFORMANCE))    ;
+                .orElseThrow( ()-> new ErrorException(NOT_FOUND_PERFORMANCES));
 
         Like existingLike = likeRepository.findByUserAndPerformance(user, performance);
 
@@ -70,7 +71,7 @@ public class LikeService {
 
     private void updateLike(Performance performance, int cnt) {
         LikeCount likeCount = likeCountRepository.findByPerformance(performance)
-                .orElseThrow(() -> new ErrorException(NOT_FOUND_PERFORMANCE));
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_PERFORMANCES));
 
         long updatedCnt = likeCount.getLikeCount() + cnt;
         updatedCnt = Math.max(0, updatedCnt); //  음수 방지

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
@@ -1,0 +1,72 @@
+package com.fifo.ticketing.domain.like.service;
+
+import com.fifo.ticketing.domain.like.dto.LikeRequest;
+import com.fifo.ticketing.domain.like.entity.Like;
+import com.fifo.ticketing.domain.like.entity.LikeCount;
+import com.fifo.ticketing.domain.like.repository.LikeCountRepository;
+import com.fifo.ticketing.domain.like.repository.LikeRepository;
+import com.fifo.ticketing.domain.performance.entity.Performance;
+import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
+import com.fifo.ticketing.domain.user.entity.User;
+import com.fifo.ticketing.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+    private final LikeRepository likeRepository;
+    private final LikeCountRepository likeCountRepository;
+    private final UserRepository userRepository;
+    private final PerformanceRepository performanceRepository;
+
+    public boolean toggleLike(LikeRequest likeRequest) {
+
+        User user = userRepository.findById(likeRequest.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("not found"));
+
+        Performance performance = performanceRepository.findById(likeRequest.getPerformanceId())
+                .orElseThrow( ()-> new EntityNotFoundException("Performance not found"))    ;
+
+        Like existingLike = likeRepository.findByUserAndPerformance(user, performance);
+
+        //like가 없다면
+        if(existingLike == null) {
+            Like like = Like.builder()
+                    .user(user)
+                    .performance(performance)
+                    .isLiked(true)
+                    .build();
+            likeRepository.save(like);
+            // likecount 제거
+            return true;
+        }//없다ㅕㄴ
+
+        if(existingLike.isLiked() ){
+            existingLike.setLiked(false);
+            likeRepository.save(existingLike);
+            updateLike(performance, -1);
+            // likeCOunt 추가
+            return false;
+        }else{
+            existingLike.setLiked(true);
+            likeRepository.save(existingLike);
+            updateLike(performance,1);
+            return true;
+
+        }
+
+    }
+
+    private void updateLike(Performance performance, int cnt) {
+        LikeCount likeCount = likeCountRepository.findByPerformance(performance)
+                .orElseThrow(() -> new EntityNotFoundException("not found"));
+
+        long updatedCnt = likeCount.getLikeCount() + cnt;
+        likeCount.setLikeCount(updatedCnt);
+        likeCountRepository.save(likeCount);
+
+    }
+}

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
@@ -9,9 +9,14 @@ import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.user.entity.User;
 import com.fifo.ticketing.domain.user.repository.UserRepository;
+import com.fifo.ticketing.global.exception.ErrorException;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_MEMBER;
+import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCE;
 
 
 @Service
@@ -22,13 +27,15 @@ public class LikeService {
     private final UserRepository userRepository;
     private final PerformanceRepository performanceRepository;
 
+
+    @Transactional
     public boolean toggleLike(LikeRequest likeRequest) {
 
         User user = userRepository.findById(likeRequest.getUserId())
-                .orElseThrow(() -> new EntityNotFoundException("not found"));
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_MEMBER));
 
         Performance performance = performanceRepository.findById(likeRequest.getPerformanceId())
-                .orElseThrow( ()-> new EntityNotFoundException("Performance not found"))    ;
+                .orElseThrow( ()-> new ErrorException(NOT_FOUND_PERFORMANCE))    ;
 
         Like existingLike = likeRepository.findByUserAndPerformance(user, performance);
 
@@ -63,7 +70,7 @@ public class LikeService {
 
     private void updateLike(Performance performance, int cnt) {
         LikeCount likeCount = likeCountRepository.findByPerformance(performance)
-                .orElseThrow(() -> new EntityNotFoundException("not found"));
+                .orElseThrow(() -> new ErrorException(NOT_FOUND_PERFORMANCE));
 
         long updatedCnt = likeCount.getLikeCount() + cnt;
         updatedCnt = Math.max(0, updatedCnt); //  음수 방지

--- a/src/main/java/com/fifo/ticketing/domain/performance/entity/Performance.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/entity/Performance.java
@@ -3,6 +3,7 @@ package com.fifo.ticketing.domain.performance.entity;
 import com.fifo.ticketing.global.entity.BaseDateEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @Table(name = "performance")
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Performance extends BaseDateEntity {
 
     @Id
@@ -44,4 +46,6 @@ public class Performance extends BaseDateEntity {
 
     @Column(nullable = false)
     private LocalDateTime reservationStartTime;
+
+
 }

--- a/src/main/java/com/fifo/ticketing/domain/user/entity/User.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/entity/User.java
@@ -1,8 +1,10 @@
 package com.fifo.ticketing.domain.user.entity;
 
+import com.fasterxml.jackson.core.JsonToken;
 import com.fifo.ticketing.global.entity.BaseDateEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class User extends BaseDateEntity {
 
     @Id
@@ -32,4 +35,6 @@ public class User extends BaseDateEntity {
 
     @Column(nullable = false)
     private boolean status;
+
+
 }

--- a/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.java
+++ b/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public enum ErrorCode {
     NOT_FOUND_MEMBER("AUTH-001", "존재하지 않는 회원입니다.", NOT_FOUND),
     SEAT_ALREADY_BOOKED("임시","해당 좌석은 이미 예약되었습니다.",SEAT_BOOKING_FAILED),
-    NOT_FOUND_PERFORMANCE("AUTH-001", "존재하지 않는 회원입니다.", NOT_FOUND);
+    NOT_FOUND_PERFORMANCES("AUTH-001", "존재하지 않는 회원입니다.", NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.java
+++ b/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
     NOT_FOUND_MEMBER("AUTH-001", "존재하지 않는 회원입니다.", NOT_FOUND),
-    SEAT_ALREADY_BOOKED("임시","해당 좌석은 이미 예약되었습니다.",SEAT_BOOKING_FAILED);
+    SEAT_ALREADY_BOOKED("임시","해당 좌석은 이미 예약되었습니다.",SEAT_BOOKING_FAILED),
+    NOT_FOUND_PERFORMANCE("AUTH-001", "존재하지 않는 회원입니다.", NOT_FOUND);
 
     private final String code;
     private final String message;

--- a/src/test/java/com/fifo/ticketing/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/fifo/ticketing/domain/like/service/LikeServiceTest.java
@@ -1,0 +1,119 @@
+package com.fifo.ticketing.domain.like.service;
+
+import com.fifo.ticketing.domain.like.dto.LikeRequest;
+import com.fifo.ticketing.domain.like.entity.Like;
+import com.fifo.ticketing.domain.like.entity.LikeCount;
+import com.fifo.ticketing.domain.like.repository.LikeCountRepository;
+import com.fifo.ticketing.domain.like.repository.LikeRepository;
+import com.fifo.ticketing.domain.performance.entity.Performance;
+import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
+import com.fifo.ticketing.domain.user.entity.User;
+import com.fifo.ticketing.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class LikeServiceTest {
+
+    @InjectMocks
+    private LikeService likeService;
+
+    @Mock
+    private LikeRepository likeRepository;
+    @Mock
+    private LikeCountRepository likeCountRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PerformanceRepository performanceRepository;
+
+    private final Long userId = 1L;
+    private final Long performanceId = 100L;
+
+    private User user;
+    private Performance performance;
+    private LikeCount likeCount;
+
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        user = User.builder().id(1L).build();
+        performance = Performance.builder().id(100L).build();
+        likeCount = LikeCount.builder().performance(performance).likeCount(1L).build();
+    }
+
+    @Test
+    void 좋아요_처음_누를_경우() {
+        LikeRequest request = new LikeRequest(user.getId(), performance.getId());
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(performanceRepository.findById(performance.getId())).thenReturn(Optional.of(performance));
+        when(likeRepository.findByUserAndPerformance(user, performance)).thenReturn(null);
+        when(likeCountRepository.findByPerformance(performance)).thenReturn(Optional.of(likeCount));
+
+        boolean result = likeService.toggleLike(request);
+
+        assertThat(result).isTrue();
+        verify(likeRepository).save(any(Like.class));
+        assertThat(likeCount.getLikeCount()).isEqualTo(2L);
+    }
+
+    @Test
+    void 이미_좋아요를_누른_상태에서_취소하는_경우() {
+        LikeRequest request = new LikeRequest(user.getId(), performance.getId());
+
+        Like existingLike = Like.builder()
+                .user(user)
+                .performance(performance)
+                .isLiked(true)
+                .build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(performanceRepository.findById(performance.getId())).thenReturn(Optional.of(performance));
+        when(likeRepository.findByUserAndPerformance(user, performance)).thenReturn(existingLike);
+        when(likeCountRepository.findByPerformance(performance)).thenReturn(Optional.of(likeCount));
+
+        boolean result = likeService.toggleLike(request);
+
+        assertThat(result).isFalse();
+        assertThat(existingLike.isLiked()).isFalse();
+        assertThat(likeCount.getLikeCount()).isEqualTo(0L);
+
+        verify(likeRepository).save(existingLike);
+        verify(likeCountRepository).save(likeCount);
+    }
+
+    @Test
+    void 좋아요_취소한상태에서_다시_좋아요를_누르는_경우(){
+        LikeRequest request = new LikeRequest(user.getId(), performance.getId());
+
+        Like existingLike = Like.builder()
+                .user(user)
+                .performance(performance)
+                .isLiked(false)
+                .build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(performanceRepository.findById(performance.getId())).thenReturn(Optional.of(performance));
+        when(likeRepository.findByUserAndPerformance(user, performance)).thenReturn(existingLike);
+        when(likeCountRepository.findByPerformance(performance)).thenReturn(Optional.of(likeCount));
+
+        boolean result = likeService.toggleLike(request);
+        assertThat(result).isTrue();
+        assertThat(existingLike.isLiked()).isTrue();
+        assertThat(likeCount.getLikeCount()).isEqualTo(2L);
+
+        verify(likeRepository).save(existingLike);
+        verify(likeCountRepository).save(likeCount);
+    }
+}


### PR DESCRIPTION
유저가 공연에 대해 좋아요를 누르는 기능을 구현했습니다.
좋아요 상태에 따라 DB에 데이터를 생성하거나 업데이트하며, 다음과 같은 로직을 따릅니다:

-해당 유저와 공연에 대한 좋아요 정보가 없을 경우 → 새로운 좋아요 데이터를 생성 (isLike = true)
likeCount +1 증가

-이미 좋아요 정보가 있을 경우

isLike = true일 때 다시 누르면 → isLike = false로 토글 
likeCount -1 감소

isLike = false일 때 다시 누르면 → isLike = true로 토글
likeCount +1 증가

작업 파일 목록
LikeService.java
UserLikeController.java
LikeRequest.java
LikeRepository.java
LikeCountRepository.java
Like.java
LikeCount.java


LikeServiceTest.java