### PR TITLE
[fix]: 공연 등록시 like_count 테이블에 해당 공연에 대한 record를 추가하도록 수정

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/like/repository/LikeCountRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/repository/LikeCountRepository.java
@@ -3,9 +3,11 @@ package com.fifo.ticketing.domain.like.repository;
 import com.fifo.ticketing.domain.like.entity.LikeCount;
 import com.fifo.ticketing.domain.performance.entity.Performance;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface LikeCountRepository extends JpaRepository<LikeCount, Long> {
     Optional<LikeCount> findByPerformance(Performance performance);
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/repository/LikeRepository.java
@@ -4,9 +4,11 @@ import com.fifo.ticketing.domain.like.entity.Like;
 import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Like findByUserAndPerformance(User user, Performance performance);
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/GradeRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/GradeRepository.java
@@ -2,11 +2,11 @@ package com.fifo.ticketing.domain.performance.repository;
 
 import com.fifo.ticketing.domain.performance.entity.Grade;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface GradeRepository extends JpaRepository<Grade, Long> {
-
     List<Grade> findAllByPlaceId(Long id);
-
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PlaceRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PlaceRepository.java
@@ -2,6 +2,8 @@ package com.fifo.ticketing.domain.performance.repository;
 
 import com.fifo.ticketing.domain.performance.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
@@ -3,6 +3,8 @@ package com.fifo.ticketing.domain.performance.service;
 import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCE;
 import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCES;
 
+import com.fifo.ticketing.domain.like.entity.LikeCount;
+import com.fifo.ticketing.domain.like.repository.LikeCountRepository;
 import com.fifo.ticketing.domain.performance.dto.PerformanceDetailResponse;
 import com.fifo.ticketing.domain.performance.mapper.PerformanceMapper;
 import com.fifo.ticketing.domain.performance.dto.PerformanceSeatGradeDto;
@@ -48,6 +50,7 @@ public class PerformanceService {
     private final GradeRepository gradeRepository;
     private final SeatService seatService;
     private final ImageFileService imageFileService;
+    private final LikeCountRepository likeCountRepository;
 
 
     @Transactional(readOnly = true)
@@ -88,8 +91,16 @@ public class PerformanceService {
         List<Seat> allSeats = generateSeatsForGrades(grades, savedPerformance);
         // Seats 저장 (Batch) - 100개 단위
         saveSeatsInBatch(allSeats);
-
+        // LikeCount 저장
+        saveLikeCount(savedPerformance);
         return savedPerformance;
+    }
+
+    private void saveLikeCount(Performance savedPerformance) {
+        likeCountRepository.save(LikeCount.builder()
+                .likeCount(0L)
+                .performance(savedPerformance)
+                .build());
     }
 
     private Place findPlace(Long placeId) {

--- a/src/test/java/com/fifo/ticketing/domain/performance/service/PerformanceServiceTests.java
+++ b/src/test/java/com/fifo/ticketing/domain/performance/service/PerformanceServiceTests.java
@@ -1,5 +1,7 @@
 package com.fifo.ticketing.domain.performance.service;
 
+import com.fifo.ticketing.domain.like.entity.LikeCount;
+import com.fifo.ticketing.domain.like.repository.LikeCountRepository;
 import com.fifo.ticketing.domain.performance.dto.PerformanceRequestDto;
 import com.fifo.ticketing.domain.performance.entity.Category;
 import com.fifo.ticketing.domain.performance.entity.Grade;
@@ -19,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,6 +51,9 @@ class PerformanceServiceTests {
 
     @Mock
     private PerformanceRepository performanceRepository;
+
+    @Mock
+    private LikeCountRepository likeCountRepository;
 
     @Mock
     private SeatService seatService;
@@ -97,6 +103,9 @@ class PerformanceServiceTests {
 
         doNothing().when(seatService).createSeats(anyList());
 
+        ArgumentCaptor<LikeCount> likeCountCaptor = ArgumentCaptor.forClass(LikeCount.class);
+        when(likeCountRepository.save(likeCountCaptor.capture())).thenReturn(LikeCount.builder().id(1L).likeCount(0L).performance(performance).build());
+
         // When
         Performance savePerformance = performanceService.createPerformance(performanceRequestDto, file);
 
@@ -106,6 +115,9 @@ class PerformanceServiceTests {
         assertThat(savePerformance.getDescription()).isEqualTo(performanceRequestDto.getDescription());
         assertThat(savePerformance.getPlace()).isEqualTo(place);
         assertThat(savePerformance.getFile()).isEqualTo(uploadedFile);
+        LikeCount savedLikeCount = likeCountCaptor.getValue();
+        assertThat(savedLikeCount.getLikeCount()).isEqualTo(0L);
+        assertThat(savedLikeCount.getPerformance()).isEqualTo(performance);
 
         // Verify
         verify(placeRepository).findById(any(Long.class));
@@ -113,6 +125,7 @@ class PerformanceServiceTests {
         verify(imageFileService).uploadFile(file);
         verify(gradeRepository).findAllByPlaceId(any(Long.class));
         verify(seatService).createSeats(anyList());
+        verify(likeCountRepository).save(any(LikeCount.class));
     }
 
     @Test


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)

- LikeCountRepository.java
- LikeRepository.java
- Graderepository.java
- PlaceRepository.java
- PerformanceService.java
- PerformanceServiceTests.java
- PerformanceApiControllerTests.java

#### 2. (작업 내용 요약)

```
    @Transactional
    public Performance createPerformance(PerformanceRequestDto dto, MultipartFile file) throws IOException {
        // Place 조회 및 존재여부 확인
        Place place = findPlace(dto.getPlaceId());
        // Performance 생성 및 DB 저장
        Performance savedPerformance = savePerformance(dto, place);
        // File 업로드
        File uploadFile = uploadFile(file);
        // performance의 File을 Update
        savedPerformance.setFile(uploadFile);
        // Grade 조회
        List<Grade> grades = findGradesByPlace(place.getId());
        // Seat 목록 생성
        List<Seat> allSeats = generateSeatsForGrades(grades, savedPerformance);
        // Seats 저장 (Batch) - 100개 단위
        saveSeatsInBatch(allSeats);
        // LikeCount 저장
        saveLikeCount(savedPerformance);
        return savedPerformance;
    }

    private void saveLikeCount(Performance savedPerformance) {
        likeCountRepository.save(LikeCount.builder()
                .likeCount(0L)
                .performance(savedPerformance)
                .build());
    }
```
상기 로직에서 saveLikeCount를 추가하였습니다.


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- LikeCount 는 단순히 Builder를 이용하여서 추가하였는데, 괜찮을지 궁금합니다.

<br/>
