### PR TITLE
[feat] 공연 목록 조회 화면에서 좋아요 기능 연동

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/api/GradeApiController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/api/GradeApiController.java
@@ -2,22 +2,22 @@ package com.fifo.ticketing.domain.performance.controller.api;
 
 import com.fifo.ticketing.domain.performance.dto.GradeResponseDto;
 import com.fifo.ticketing.domain.performance.service.GradeService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/grades")
 @RequiredArgsConstructor
 public class GradeApiController {
+
     private final GradeService gradeService;
 
     @GetMapping("/places/{placeId}")
-    public List<GradeResponseDto> getGradesByPlace(@PathVariable Long placeId) {
+    public List<GradeResponseDto> getGradesByPlace(@PathVariable(value = "placeId") Long placeId) {
         return gradeService.getGradesByPlaceId(placeId);
     }
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/dto/PerformanceResponseDto.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/dto/PerformanceResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PerformanceResponseDto {
 
+    private Long id;
     private String encodedFileName;
     private String title;
     private String category;
@@ -20,9 +21,10 @@ public class PerformanceResponseDto {
     private boolean performanceStatus;
 
     @Builder
-    public PerformanceResponseDto(String encodedFileName, String title, String category,
+    public PerformanceResponseDto(Long id, String encodedFileName, String title, String category,
         String place, LocalDateTime startTime, LocalDateTime endTime,
         LocalDateTime reservationStartTime, boolean performanceStatus) {
+        this.id = id;
         this.encodedFileName = encodedFileName;
         this.title = title;
         this.category = category;

--- a/src/main/java/com/fifo/ticketing/domain/performance/mapper/PerformanceMapper.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/mapper/PerformanceMapper.java
@@ -1,15 +1,14 @@
 package com.fifo.ticketing.domain.performance.mapper;
 
 import com.fifo.ticketing.domain.performance.dto.PerformanceDetailResponse;
+import com.fifo.ticketing.domain.performance.dto.PerformanceRequestDto;
 import com.fifo.ticketing.domain.performance.dto.PerformanceResponseDto;
 import com.fifo.ticketing.domain.performance.dto.PerformanceSeatGradeDto;
 import com.fifo.ticketing.domain.performance.entity.Grade;
-import com.fifo.ticketing.domain.performance.dto.PerformanceRequestDto;
 import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.performance.entity.Place;
-import org.springframework.data.domain.Page;
-
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public class PerformanceMapper {
 
@@ -29,12 +28,12 @@ public class PerformanceMapper {
             .defaultPrice(grade.getDefaultPrice()).seatCount(grade.getSeatCount()).build();
     }
 
-
     private PerformanceMapper() {
     }
 
     private static PerformanceResponseDto toPerformanceResponseDto(Performance performance) {
         return PerformanceResponseDto.builder()
+            .id(performance.getId())
             .encodedFileName(performance.getFile().getEncodedFileName())
             .title(performance.getTitle())
             .category(performance.getCategory().name())
@@ -44,21 +43,22 @@ public class PerformanceMapper {
             .reservationStartTime(performance.getReservationStartTime())
             .performanceStatus(performance.isPerformanceStatus()).build();
     }
-  
+
     public static Performance toEntity(PerformanceRequestDto dto, Place place) {
         return Performance.builder()
-                .title(dto.getTitle())
-                .description(dto.getDescription())
-                .place(place)
-                .startTime(dto.getStartTime())
-                .endTime(dto.getEndTime())
-                .category(dto.getCategory())
-                .performanceStatus(dto.isPerformanceStatus())
-                .reservationStartTime(dto.getReservationStartTime())
-                .build();
+            .title(dto.getTitle())
+            .description(dto.getDescription())
+            .place(place)
+            .startTime(dto.getStartTime())
+            .endTime(dto.getEndTime())
+            .category(dto.getCategory())
+            .performanceStatus(dto.isPerformanceStatus())
+            .reservationStartTime(dto.getReservationStartTime())
+            .build();
     }
 
-    public static Page<PerformanceResponseDto> toPagePerformanceResponseDto(Page<Performance> performances) {
+    public static Page<PerformanceResponseDto> toPagePerformanceResponseDto(
+        Page<Performance> performances) {
         return performances.map(PerformanceMapper::toPerformanceResponseDto);
     }
 }

--- a/src/main/resources/templates/view_performances.html
+++ b/src/main/resources/templates/view_performances.html
@@ -24,6 +24,18 @@
       margin-top: 80px;
     }
 
+    .like-button {
+      font-size: 14px;
+      padding: 4px 8px;
+      border-radius: 50%;
+      line-height: 1;
+      transition: background-color 0.2s ease;
+    }
+
+    .like-button:hover {
+      background-color: #c82333;
+    }
+
     .pagination-container {
       margin-top: 30px;
       display: flex;
@@ -129,9 +141,17 @@
         <tbody>
         <tr th:each="performance : ${performances}">
           <td>
-            <img th:src="@{/image/{fileName}(fileName=${performance.encodedFileName})}"
-                 alt="no image"
-                 style="width: 100px; height: auto; object-fit: cover;"/>
+            <div class="image-wrapper" style="position: relative; width: 100px;">
+              <img th:src="@{/image/{fileName}(fileName=${performance.encodedFileName})}"
+                   alt="no image"
+                   style="width: 100px; height: auto; object-fit: cover;"/>
+
+              <button class="like-button btn btn-sm btn-danger"
+                      style="position: absolute; bottom: 5px; right: 5px;"
+                      th:data-id="${performance.id}">
+                ♡
+              </button>
+            </div>
           </td>
           <td th:text="${performance.title}"></td>
           <td th:text="${performance.category}"></td>
@@ -245,6 +265,29 @@
     const url = `/performances?startDate=${encodeURIComponent(
         startDate)}&endDate=${encodeURIComponent(endDate)}`;
     location.href = url;
+  });
+
+  $(document).on("click", ".like-button", function () {
+    const $btn = $(this);
+    const performanceId = $btn.data("id");
+
+    $.ajax({
+      type: "POST",
+      url: "/user/like",
+      contentType: "application/json",
+      data: JSON.stringify({
+        userId: 1,
+        performanceId: performanceId
+      }),
+      success: function (response) {
+        // ♥ / ♡ 토글
+        const current = $btn.text().trim();
+        $btn.text(current === "♡" ? "♥" : "♡");
+      },
+      error: function () {
+        alert("좋아요 처리 중 오류가 발생했습니다.");
+      }
+    });
   });
 </script>
 


### PR DESCRIPTION
## ✨ 설명

- #20 
- 좋아요 API 연동
    - 세션에서 사용자 정보를 받아와서 likes 테이블에 추가
- 좋아요 버튼 UI 추가
    - 토글 상태에 따른 좋아요 개수 증감 확인

#### 1. (작업 파일)

GradeApiController
PerformanceController
PerformanceResponseDto
PerformanceMapper
view_performances.html

#### 2. (작업 내용 요약)
![image](https://github.com/user-attachments/assets/93683eb4-883d-48d4-adef-9142f68585d9)
![image](https://github.com/user-attachments/assets/3fc3e97a-3d0b-4d84-af22-77f2752d9167)
![image](https://github.com/user-attachments/assets/bfeb5f55-94df-4b55-b789-d4d3078ca241)

<br/>

## 💬 리뷰
- 제가 작업한 부분에 대한 것만 연동을 진행해서 이후에 UserLikeController, LikeService의 로그인한 사용자의 id를 받아오는 부분이 수정된다면 정상 동작할 것입니다.
- 사용자의 좋아요 목록 상태에 따라 공연 목록 페이지에서 좋아요 버튼 토글 상태가 다르게 보이도록 하는 작업은 이것과 관련된 기능을 개발하고 있는 다른 팀원의 작업이 끝나고 난 다음 다룰 예정입니다. 

<br/>
