### PR TITLE
[refactor] LikeService id 세션으로 변환

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/like/controller/UserLikeController.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/controller/UserLikeController.java
@@ -2,7 +2,8 @@ package com.fifo.ticketing.domain.like.controller;
 
 import com.fifo.ticketing.domain.like.dto.LikeRequest;
 import com.fifo.ticketing.domain.like.service.LikeService;
-import lombok.Getter;
+import com.fifo.ticketing.domain.user.dto.SessionUser;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,8 +16,13 @@ public class UserLikeController {
     private final LikeService likeService;
 
     @PostMapping
-    public ResponseEntity<String> toggleLike(@RequestBody LikeRequest likeRequest){
-        boolean liked = likeService.toggleLike(likeRequest);
+    public ResponseEntity<String> toggleLike(@RequestBody LikeRequest likeRequest
+        ,HttpSession httpSession){
+        //LoginSuccessHandler에서 SessionUser로 저장했기 때문에
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("loginUser");
+
+        // record라서 .getId()가 아니라 .id()
+        boolean liked = likeService.toggleLike(sessionUser.id() , likeRequest);
         return ResponseEntity.ok(liked ? "Liked" : "Unliked");
     }
 

--- a/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikeRequest {
 
-    //private Long userId;
     private Long performanceId;
 
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/dto/LikeRequest.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class LikeRequest {
 
-    private Long userId;
+    //private Long userId;
     private Long performanceId;
 
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
@@ -10,6 +10,7 @@ import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.user.entity.User;
 import com.fifo.ticketing.global.exception.ErrorException;
+import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,7 @@ public class LikeMailNotificationService {
     private final LikeMailService likeMailService;
     private final PerformanceRepository performanceRepository;
 
+    @Transactional
     public boolean sendLikeNotification(Long performanceId) {
         Performance performance = performanceRepository.findById(performanceId)
             .orElseThrow( ()-> new ErrorException(NOT_FOUND_PERFORMANCES));

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeService.java
@@ -30,9 +30,9 @@ public class LikeService {
 
 
     @Transactional
-    public boolean toggleLike(LikeRequest likeRequest) {
+    public boolean toggleLike(Long userId, LikeRequest likeRequest) {
 
-        User user = userRepository.findById(likeRequest.getUserId())
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorException(NOT_FOUND_MEMBER));
 
         Performance performance = performanceRepository.findById(likeRequest.getPerformanceId())

--- a/src/test/java/com/fifo/ticketing/domain/like/service/LikeServiceTest.java
+++ b/src/test/java/com/fifo/ticketing/domain/like/service/LikeServiceTest.java
@@ -54,14 +54,15 @@ class LikeServiceTest {
 
     @Test
     void 좋아요_처음_누를_경우() {
-        LikeRequest request = new LikeRequest(user.getId(), performance.getId());
+
+        LikeRequest request = new LikeRequest(performance.getId());
 
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(performanceRepository.findById(performance.getId())).thenReturn(Optional.of(performance));
         when(likeRepository.findByUserAndPerformance(user, performance)).thenReturn(null);
         when(likeCountRepository.findByPerformance(performance)).thenReturn(Optional.of(likeCount));
 
-        boolean result = likeService.toggleLike(request);
+        boolean result = likeService.toggleLike(userId, request);
 
         assertThat(result).isTrue();
         verify(likeRepository).save(any(Like.class));
@@ -70,7 +71,7 @@ class LikeServiceTest {
 
     @Test
     void 이미_좋아요를_누른_상태에서_취소하는_경우() {
-        LikeRequest request = new LikeRequest(user.getId(), performance.getId());
+        LikeRequest request = new LikeRequest(performance.getId());
 
         Like existingLike = Like.builder()
                 .user(user)
@@ -83,7 +84,7 @@ class LikeServiceTest {
         when(likeRepository.findByUserAndPerformance(user, performance)).thenReturn(existingLike);
         when(likeCountRepository.findByPerformance(performance)).thenReturn(Optional.of(likeCount));
 
-        boolean result = likeService.toggleLike(request);
+        boolean result = likeService.toggleLike(userId,request);
 
         assertThat(result).isFalse();
         assertThat(existingLike.isLiked()).isFalse();
@@ -95,7 +96,7 @@ class LikeServiceTest {
 
     @Test
     void 좋아요_취소한상태에서_다시_좋아요를_누르는_경우(){
-        LikeRequest request = new LikeRequest(user.getId(), performance.getId());
+        LikeRequest request = new LikeRequest( performance.getId());
 
         Like existingLike = Like.builder()
                 .user(user)
@@ -108,7 +109,7 @@ class LikeServiceTest {
         when(likeRepository.findByUserAndPerformance(user, performance)).thenReturn(existingLike);
         when(likeCountRepository.findByPerformance(performance)).thenReturn(Optional.of(likeCount));
 
-        boolean result = likeService.toggleLike(request);
+        boolean result = likeService.toggleLike(userId,request);
         assertThat(result).isTrue();
         assertThat(existingLike.isLiked()).isTrue();
         assertThat(likeCount.getLikeCount()).isEqualTo(2L);


### PR DESCRIPTION
Refactor/#29/shs
## ✨ 설명

UserLikeController, LikeService의 로그인한 사용자의 id를 받아오는 부분이 세션으로 받게 수정

#### 1. (작업 파일)
UserLikeController.java
LikeRequest.java
LikeServiceTest.java
LikeService.java
LikeMailNotificationService.java
#### 2. (작업 내용 요약)

request dto에서 id 제거


api 요청 할때마다 토글 확인
![image](https://github.com/user-attachments/assets/d59d7920-a361-4f45-8971-17ec08d6eb85)
![image](https://github.com/user-attachments/assets/8f2eb17f-80de-404c-a53f-2862447cbe47)


코드
![image](https://github.com/user-attachments/assets/06f0ec0f-6e96-49ea-bcd7-9d5c6eef6b54)
세션에서 가져오게 설정


## 💬 리뷰

