### PR TITLE
[feat] 예매 취소 스케줄러 구현

### DIFF
--- a/src/main/java/com/fifo/ticketing/TicketingApplication.java
+++ b/src/main/java/com/fifo/ticketing/TicketingApplication.java
@@ -4,10 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
-//@EnableScheduling 스케줄링 추가시
+@EnableScheduling
 public class TicketingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fifo/ticketing/domain/book/service/BookCancelService.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/service/BookCancelService.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BookCancelService {
@@ -37,16 +36,9 @@ public class BookCancelService {
                 seat.available();
             }
 
-            log.info("===================스케줄러=====================");
-            log.info("{}번 예매 생성 시간", book.getCreatedAt());
-            log.info("{}번 예매 자동 취소", book.getId());
-            log.info("{}번 예매 취소 시간", book.getUpdatedAt());
-            log.info("==============================================");
-
         }
 
     }
-
 
 
 }

--- a/src/main/java/com/fifo/ticketing/domain/book/service/BookCancelService.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/service/BookCancelService.java
@@ -1,0 +1,52 @@
+package com.fifo.ticketing.domain.book.service;
+
+import com.fifo.ticketing.domain.book.entity.Book;
+import com.fifo.ticketing.domain.book.entity.BookSeat;
+import com.fifo.ticketing.domain.book.entity.BookStatus;
+import com.fifo.ticketing.domain.book.repository.BookRepository;
+import com.fifo.ticketing.domain.book.repository.BookSeatRepository;
+import com.fifo.ticketing.domain.seat.entity.Seat;
+import com.fifo.ticketing.global.exception.ErrorCode;
+import com.fifo.ticketing.global.exception.ErrorException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookCancelService {
+
+    private final BookRepository bookRepository;
+    private final BookSeatRepository bookSeatRepository;
+
+    @Transactional
+    public void cancelIfUnpaid(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+            .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_BOOK));
+
+        if (book.getBookStatus() == BookStatus.CONFIRMED) {
+
+            List<BookSeat> bookSeats = bookSeatRepository.findAllByBookId(book.getId());
+            book.canceled();
+
+            for (BookSeat bookSeat : bookSeats) {
+                Seat seat = bookSeat.getSeat();
+                seat.available();
+            }
+
+            log.info("===================스케줄러=====================");
+            log.info("{}번 예매 생성 시간", book.getCreatedAt());
+            log.info("{}번 예매 자동 취소", book.getId());
+            log.info("{}번 예매 취소 시간", book.getUpdatedAt());
+            log.info("==============================================");
+
+        }
+
+    }
+
+
+
+}

--- a/src/main/java/com/fifo/ticketing/domain/book/service/BookService.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/service/BookService.java
@@ -80,9 +80,7 @@ public class BookService {
 
         Long bookId = book.getId();
 
-        // 10분 뒤 작업 예약
         LocalDateTime runTime = LocalDateTime.now().plusMinutes(1);
-        // taskScheduler는 작업 실행 시간을 date 타입으로 받아서 변환행주어야 함.
         Date triggerTime = Date.from(runTime.atZone(ZoneId.systemDefault()).toInstant());
 
         taskScheduler.schedule(() -> bookCancelService.cancelIfUnpaid(bookId), triggerTime);

--- a/src/main/java/com/fifo/ticketing/global/config/SchedulerConfig.java
+++ b/src/main/java/com/fifo/ticketing/global/config/SchedulerConfig.java
@@ -1,0 +1,19 @@
+package com.fifo.ticketing.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("book-cancel-task-");
+        scheduler.initialize();
+
+        return scheduler;
+    }
+}

--- a/src/main/resources/templates/performance/detail.html
+++ b/src/main/resources/templates/performance/detail.html
@@ -143,6 +143,7 @@
     <form id="bookForm" th:action="@{'/performances/' + ${performanceId} + '/book'}" method="post">
       <input type="hidden" name="userId" th:value="${userId}"/>
       <input type="hidden" name="seatIds" id="seatIdsInput"/>
+      <p>10분 내 결제가 완료되지 않을 시 예매가 취소됩니다.</p>
       <button type="submit" id="bookBtn" disabled>예매하기</button>
     </form>
   </div>


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->
#47 


@Scheduled 어노테이션이 아닌 TaskScheduler를 사용하였습니다.
@Scheduled는 작업을 일정 시간마다 반복합니다 ( 1분마다 실행, 매일 2시에 실행 )
사용자의 예매는 동적으로 발생하기 때문에 해당 반복은 비효율적이라고 생각했습니다.

TaskScheduler는 작업을 미래 시점에 예약해둡니다.
예매가 생성되는 순간, 10분 후로 예약을 해두어 결제가 안되었다면 취소 되도록 구현하였습니다.

#### 1. (작업 파일)

- TicketingApplication.java
- book/service/BookCancelService.java
- book/service/BookService.java
- global/config/SchedulerConfig.java
- templates/performance/detail.html

#### 2. (작업 내용 요약)

```java
@Configuration
public class SchedulerConfig {

    @Bean
    public ThreadPoolTaskScheduler taskScheduler() {
        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
        scheduler.setPoolSize(5);
        scheduler.setThreadNamePrefix("book-cancel-task-");
        scheduler.initialize();

        return scheduler;
    }
}
```
- 일단 스레드 풀 사이즈를 5로 잡았습니다.
- 그래서 만약 예매 6건이 이어서 생성된다면 6번째 작업은 첫번째 작업이 끝날 때까지 대기하게 됩니다.

```java
        // 10분 뒤 작업 예약
        LocalDateTime runTime = LocalDateTime.now().plusMinutes(1);
        // taskScheduler는 작업 실행 시간을 date 타입으로 받아서 변환행주어야 함.
        Date triggerTime = Date.from(runTime.atZone(ZoneId.systemDefault()).toInstant());

        taskScheduler.schedule(() -> bookCancelService.cancelIfUnpaid(bookId), triggerTime);
```
- createBook 메소드 안에 schedule 생성 코드를 추가했습니다.
- 테스트를 빠르게 진행하기 위해 작업 시간은 1분 후로 설정해두었습니다!

<br/>

**테스트 예매 생성**
![스크린샷 2025-05-14 093240](https://github.com/user-attachments/assets/316e7447-07aa-40cc-b8ad-8f5205339876)

- 예매 3건을 생성 후 결제를 진행하지 않았습니다.

<br/>

**스케줄러 로그 확인**
![스크린샷 2025-05-14 093357](https://github.com/user-attachments/assets/df88e404-a060-4696-ab21-7fb4e43bd816)

- log를 찍어 스케줄러가 동작하는지 확인해보았습니다.

<br/>

**테스트 예매 취소 확인**
![스크린샷 2025-05-14 093334](https://github.com/user-attachments/assets/ef0a799f-ee8f-4c2e-8f11-0ba6e3f1c7b9)

- 해당 예매들이 취소되었습니다!

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

TaskScheduler는 메모리 기반으로 수행되기 때문에, 프로그램을 끄면 예약된 작업이 사라집니다..
해결하려면 엔티티를 생성해서 예약 정보를 DB에 저장 후 프로그램이 시작될 때마다 작업들을 스케줄러에 등록해야 하는 것 같습니다.
일단 DB 저장 없이 구현하긴 했는데 해당 부분 어떻게 생각하시나요!

<br/>
