### PR TITLE
[fix] 공연 목록 조회 쿼리 수정, 공연 목록 조회 요청에 대한 예외처리

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
@@ -5,11 +5,11 @@ import com.fifo.ticketing.domain.book.dto.BookSeatViewDto;
 import com.fifo.ticketing.domain.like.service.LikeService;
 import com.fifo.ticketing.domain.performance.dto.PerformanceDetailResponse;
 import com.fifo.ticketing.domain.performance.dto.PerformanceResponseDto;
-import com.fifo.ticketing.domain.performance.dto.PlaceResponseDto;
 import com.fifo.ticketing.domain.performance.entity.Category;
 import com.fifo.ticketing.domain.performance.service.PerformanceService;
 import com.fifo.ticketing.domain.seat.service.SeatService;
 import com.fifo.ticketing.domain.user.dto.SessionUser;
+import com.fifo.ticketing.global.util.UserValidator;
 import jakarta.servlet.http.HttpSession;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -125,10 +125,11 @@ public class PerformanceController {
     }
 
     private void preparedModel(HttpSession session, Model model,
-        Page<PerformanceResponseDto> performances, int page,
-        String baseQuery) {
+        Page<PerformanceResponseDto> performances, int page, String baseQuery) {
+        UserValidator.validateSessionUser(session);
         SessionUser loginUser = (SessionUser) session.getAttribute("loginUser");
         Long userId = loginUser.id();
+
         List<Long> likedPerformancesIds = likeService.getLikedPerformancesIds(userId);
 
         model.addAttribute("userId", userId);

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
@@ -21,7 +21,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             "ORDER BY p.reservationStartTime ASC, p.startTime ASC",
         countQuery = "SELECT COUNT(p) FROM Performance p WHERE p.startTime > :now"
     )
-    Page<Performance> findUpcomingPerformancesOrderByReservationStartTime(
+    Page<Performance> findUpcomingPerformancesOrderByStartTime(
         @Param("now") LocalDateTime now, Pageable pageable);
 
     @EntityGraph(attributePaths = {"file"})

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
@@ -5,6 +5,7 @@ import com.fifo.ticketing.domain.performance.entity.Performance;
 import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,57 +14,78 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PerformanceRepository extends JpaRepository<Performance, Long> {
 
-    @Query("SELECT p FROM Performance p " +
-        "JOIN FETCH p.file " +
-        "WHERE p.reservationStartTime > :now " +
-        "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
+    @EntityGraph(attributePaths = {"file"})
+    @Query(
+        value = "SELECT p FROM Performance p " +
+            "WHERE p.startTime > :now " +
+            "ORDER BY p.reservationStartTime ASC, p.startTime ASC",
+        countQuery = "SELECT COUNT(p) FROM Performance p WHERE p.startTime > :now"
+    )
     Page<Performance> findUpcomingPerformancesOrderByReservationStartTime(
         @Param("now") LocalDateTime now, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"file"})
+    @Query(
+        value = "SELECT p FROM Performance p " +
+            "LEFT JOIN LikeCount lc ON lc.performance = p " +
+            "WHERE p.startTime > :now " +
+            "ORDER BY COALESCE(lc.likeCount, 0) DESC, p.reservationStartTime ASC",
+        countQuery = "SELECT COUNT(p) FROM Performance p WHERE p.startTime > :now"
+    )
+    Page<Performance> findUpcomingPerformancesOrderByLikes(
+        @Param("now") LocalDateTime now,
+        Pageable pageable);
+
+    @EntityGraph(attributePaths = {"file"})
+    @Query(
+        value = "SELECT p FROM Performance p " +
+            "WHERE p.startTime BETWEEN :startDate AND :endDate " +
+            "ORDER BY p.reservationStartTime ASC, p.startTime ASC",
+        countQuery = "SELECT COUNT(p) FROM Performance p " +
+            "WHERE p.startTime BETWEEN :startDate AND :endDate"
+    )
+    Page<Performance> findUpcomingPerformancesByReservationPeriod(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        Pageable pageable);
+
+    @EntityGraph(attributePaths = {"file"})
+    @Query(
+        value = "SELECT p FROM Performance p " +
+            "WHERE p.startTime > :now AND p.category = :category " +
+            "ORDER BY p.reservationStartTime ASC, p.startTime ASC",
+        countQuery = "SELECT COUNT(p) FROM Performance p " +
+            "WHERE p.startTime > :now AND p.category = :category"
+    )
+    Page<Performance> findUpcomingPerformancesByCategory(
+        @Param("now") LocalDateTime now,
+        @Param("category") Category category,
+        Pageable pageable);
+
     @Query("SELECT p FROM Performance p " +
-        "LEFT JOIN LikeCount lc ON lc.performance = p " +
-        "WHERE p.reservationStartTime > :now " +
-        "ORDER BY COALESCE(lc.likeCount, 0) DESC, p.reservationStartTime ASC")
-    Page<Performance> findUpcomingPerformancesOrderByLikes(@Param("now") LocalDateTime now,
+        "JOIN FETCH p.file " +
+        "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
+    Page<Performance> findUpcomingPerformancesOrderByReservationStartTimeForAdmin(
         Pageable pageable);
 
     @Query("SELECT p FROM Performance p " +
         "WHERE p.reservationStartTime BETWEEN :startDate AND :endDate " +
         "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
-    Page<Performance> findUpcomingPerformancesByReservationPeriod(
+    Page<Performance> findUpcomingPerformancesByReservationPeriodForAdmin(
         @Param("startDate") LocalDateTime startDate,
         @Param("endDate") LocalDateTime endDate,
         Pageable pageable
     );
 
     @Query("SELECT p FROM Performance p " +
-        "WHERE p.reservationStartTime > :now and p.category = :category " +
+        "WHERE p.category = :category " +
         "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
-    Page<Performance> findUpcomingPerformancesByCategory(@Param("now") LocalDateTime now,
+    Page<Performance> findUpcomingPerformancesByCategoryForAdmin(
         @Param("category") Category category, Pageable pageable);
 
-    @Query("SELECT p FROM Performance p " +
-            "JOIN FETCH p.file " +
-            "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
-    Page<Performance> findUpcomingPerformancesOrderByReservationStartTimeForAdmin(Pageable pageable);
-
-    @Query("SELECT p FROM Performance p " +
-            "WHERE p.reservationStartTime BETWEEN :startDate AND :endDate " +
-            "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
-    Page<Performance> findUpcomingPerformancesByReservationPeriodForAdmin(
-            @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate,
-            Pageable pageable
-    );
-
-    @Query("SELECT p FROM Performance p " +
-            "WHERE p.category = :category " +
-            "ORDER BY p.reservationStartTime ASC, p.startTime ASC")
-    Page<Performance> findUpcomingPerformancesByCategoryForAdmin(@Param("category") Category category, Pageable pageable);
-
     @Query("SELECT p FROM Performance p" +
-            " LEFT JOIN LikeCount lc ON lc.performance = p " +
-            " ORDER BY COALESCE(lc.likeCount, 0) DESC, p.reservationStartTime ASC")
+        " LEFT JOIN LikeCount lc ON lc.performance = p " +
+        " ORDER BY COALESCE(lc.likeCount, 0) DESC, p.reservationStartTime ASC")
     Page<Performance> findUpcomingPerformancesOrderByLikesForAdmin(Pageable pageable);
 
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
@@ -74,7 +74,7 @@ public class PerformanceService {
 
     @Transactional(readOnly = true)
     public Page<PerformanceResponseDto> getPerformancesSortedByLatest(Pageable pageable) {
-        Page<Performance> performances = performanceRepository.findUpcomingPerformancesOrderByReservationStartTime(
+        Page<Performance> performances = performanceRepository.findUpcomingPerformancesOrderByStartTime(
             LocalDateTime.now(), pageable);
         if (performances.isEmpty()) {
             throw new ErrorException(NOT_FOUND_PERFORMANCES);

--- a/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.java
+++ b/src/main/java/com/fifo/ticketing/global/exception/ErrorCode.java
@@ -1,10 +1,11 @@
 package com.fifo.ticketing.global.exception;
 
 import static com.fifo.ticketing.global.exception.ErrorStatus.ALREADY_EXISTS;
-import static com.fifo.ticketing.global.exception.ErrorStatus.CONFLICT;
 import static com.fifo.ticketing.global.exception.ErrorStatus.BAD_REQUEST;
+import static com.fifo.ticketing.global.exception.ErrorStatus.CONFLICT;
 import static com.fifo.ticketing.global.exception.ErrorStatus.INTERNAL_SERVER_ERROR;
 import static com.fifo.ticketing.global.exception.ErrorStatus.NOT_FOUND;
+import static com.fifo.ticketing.global.exception.ErrorStatus.UNAUTHORIZED;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,8 +27,8 @@ public enum ErrorCode {
     EMAIL_ALREADY_EXISTS("EMAIL-001", "이미 사용하는 이메일입니다.", ALREADY_EXISTS),
     NOT_FOUND_AUTH("AUTH-002", "잘못된 인증번호 입니다.", NOT_FOUND),
     NOT_FOUND_PROVIDER("PROVIDER-001", "지원하지 않는 플랫폼 서비스입니다.", NOT_FOUND),
-    NOT_FOUND_BOOK("BOOK-001", "예약 정보가 존재하지 않습니다.", NOT_FOUND);
-
+    NOT_FOUND_BOOK("BOOK-001", "예약 정보가 존재하지 않습니다.", NOT_FOUND),
+    UNAUTHORIZED_REQUEST("AUTH-003", "올바른 요청이 아닙니다. 로그인을 해주세요.", UNAUTHORIZED);
 
     private final String code;
     private final String message;

--- a/src/main/java/com/fifo/ticketing/global/exception/ErrorStatus.java
+++ b/src/main/java/com/fifo/ticketing/global/exception/ErrorStatus.java
@@ -5,5 +5,6 @@ public enum ErrorStatus {
     CONFLICT,
     INTERNAL_SERVER_ERROR,
     ALREADY_EXISTS,
-    BAD_REQUEST
+    BAD_REQUEST,
+    UNAUTHORIZED
 }

--- a/src/main/java/com/fifo/ticketing/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/fifo/ticketing/global/exception/ExceptionAdvice.java
@@ -16,35 +16,36 @@ public class ExceptionAdvice {
 
     @ExceptionHandler({ErrorException.class, AlertDetailException.class})
     public Object handleException(
-            RuntimeException ex,
-            Model model,
-            HandlerMethod handlerMethod
+        RuntimeException ex,
+        Model model,
+        HandlerMethod handlerMethod
     ) {
-        boolean isApiRequest = AnnotatedElementUtils.hasAnnotation(handlerMethod.getMethod(), ResponseBody.class);
+        boolean isApiRequest = AnnotatedElementUtils.hasAnnotation(handlerMethod.getMethod(),
+            ResponseBody.class);
 
         // 예외 타입에 따라 처리
         if (ex instanceof ErrorException errorException) {
             return handleCommonException(
-                    errorException.getErrorCode(),
-                    errorException.getUrl(),
-                    isApiRequest,
-                    model,
-                    errorException
+                errorException.getErrorCode(),
+                errorException.getUrl(),
+                isApiRequest,
+                model,
+                errorException
             );
         } else if (ex instanceof AlertDetailException alertDetailException) {
             return handleCommonException(
-                    alertDetailException.getErrorCode(),
-                    alertDetailException.getUrl(),
-                    isApiRequest,
-                    model,
-                    alertDetailException
+                alertDetailException.getErrorCode(),
+                alertDetailException.getUrl(),
+                isApiRequest,
+                model,
+                alertDetailException
             );
         }
         // 알 수 없는 예외에 대해서는 기본 에러 처리
         log.error("Unhandled exception: ", ex);
         if (isApiRequest) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ErrorResponse("500", "Unexpected error occurred"));
+                .body(new ErrorResponse("500", "Unexpected error occurred"));
         } else {
             model.addAttribute("message", "Unexpected error occurred");
             model.addAttribute("url", "/");
@@ -53,11 +54,11 @@ public class ExceptionAdvice {
     }
 
     private Object handleCommonException(
-            ErrorCode errorCode,
-            String url,
-            boolean isApiRequest,
-            Model model,
-            Exception ex
+        ErrorCode errorCode,
+        String url,
+        boolean isApiRequest,
+        Model model,
+        Exception ex
     ) {
         log.error(errorCode.getMessage(), ex);
 
@@ -67,12 +68,12 @@ public class ExceptionAdvice {
                 // 필요한 경우 다른 상태 추가
                 case CONFLICT -> HttpStatus.CONFLICT;
                 case INTERNAL_SERVER_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
-                case ALREADY_EXISTS -> HttpStatus.BAD_REQUEST;
-                case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
+                case ALREADY_EXISTS, BAD_REQUEST -> HttpStatus.BAD_REQUEST;
+                case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
             };
 
             return ResponseEntity.status(httpStatus)
-                    .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));
+                .body(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()));
         } else {
             model.addAttribute("message", errorCode.getMessage());
             model.addAttribute("url", url);

--- a/src/main/java/com/fifo/ticketing/global/util/UserValidator.java
+++ b/src/main/java/com/fifo/ticketing/global/util/UserValidator.java
@@ -1,0 +1,19 @@
+package com.fifo.ticketing.global.util;
+
+import com.fifo.ticketing.domain.user.dto.SessionUser;
+import com.fifo.ticketing.global.exception.ErrorCode;
+import com.fifo.ticketing.global.exception.ErrorException;
+import jakarta.servlet.http.HttpSession;
+
+public class UserValidator {
+
+    private UserValidator() {
+    }
+
+    public static void validateSessionUser(HttpSession session) {
+        SessionUser user = (SessionUser) session.getAttribute("loginUser");
+        if (user == null) {
+            throw new ErrorException("user/sign_in", ErrorCode.UNAUTHORIZED_REQUEST);
+        }
+    }
+}


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명
- #39 
- #38 
- 공연 목록 조회 쿼리 수정
    - 지금 이후에 예매가 열리는 공연(x) -> 지금 이후에 시작되는 공연(o)
    - 공연 시작 전까지 예매가 가능하다는 전제를 반영
- 세션 관련 예외처리
    - 로그인 하지 않은 사용자에 대한 요청 에외처리
    - 로그인 하지 않고 요청을 보내는 경우, alert 창을 띄우고 로그인 화면으로 리다이렉션 처리

#### 1. (작업 파일)
- PerformanceController
- PerformanceRepository
- ErrorCode
- ErrorStatus
- ExceptionAdvice
- UserValidator

#### 2. (작업 내용 요약)
![image](https://github.com/user-attachments/assets/95a61c81-32ef-4ddb-b966-418c622ea54b)
공연 시작 전까지 예매가 가능하다는 전제를 반영하여 쿼리 조건절을 수정했습니다. 지금 이후에 예매가 열리는 공연을 조회하는 것이 아닌 지금 이후에 시작되는 공연을 모두 조회하도록 했습니다.
<br/>
![image](https://github.com/user-attachments/assets/666615aa-ad76-4c04-af75-de8210178a71)
컨트롤러마다 세션에 접근해서 유효한 user에 대한 요청인지 확인하는 코드가 중복될 것이라 생각하여, global/util 패키지에 UserValidator를 추가했습니다.

<br/>

## 💬 리뷰
- 컨트롤러마다 세션에 접근해서 유효한 user에 대한 요청인지 확인하는 코드가 중복되어 리팩토링의 필요성을 느꼈습니다. 그래서 util 메서드로 UserValidator를 추가했습니다. 그런데 작업을 마친 후에, 세션 관련 예외처리는 컨트롤러에서 진행하는 것이 아니라 SecurityFilter에 등록을 해서 유효한 user의 요청이 아니면 컨트롤러로 요청이 전달되지 않도록 해야 하는 것 아닌가?라는 생각이 들었습니다. 다들 이 부분에 대해 어떻게 생각하시나요?
<br/>
