### PR TITLE
[feat] 로그인 실패 처리 로직 보완

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/user/controller/ViewController.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/controller/ViewController.java
@@ -5,6 +5,7 @@ import com.fifo.ticketing.domain.book.service.BookService;
 import com.fifo.ticketing.domain.user.dto.SessionUser;
 import com.fifo.ticketing.domain.user.dto.form.SignUpForm;
 import com.fifo.ticketing.domain.user.service.UserFormService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Slf4j
@@ -36,7 +36,11 @@ public class ViewController {
     }
 
     @GetMapping("/users/signup")
-    public String signup() {
+    public String signup(HttpServletRequest request) {
+        SessionUser loginUser = (SessionUser) request.getSession().getAttribute("loginUser");
+        if (loginUser != null) {
+            return "redirect:/";
+        }
         return "user/sign_up";
     }
 
@@ -56,7 +60,17 @@ public class ViewController {
     }
 
     @GetMapping("/users/signin")
-    public String signin() {
+    public String signin(HttpServletRequest request, Model model) {
+        SessionUser loginUser = (SessionUser) request.getSession().getAttribute("loginUser");
+        if (loginUser != null) {
+            return "redirect:/";
+        }
+        String errormessage = (String) request.getSession().getAttribute("errormessage");
+        if (errormessage != null) {
+            model.addAttribute("errorMessage", errormessage);
+            request.getSession().removeAttribute("errormessage");
+        }
+
         return "user/sign_in";
     }
 

--- a/src/main/java/com/fifo/ticketing/domain/user/service/FormLoginFailureHandler.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/service/FormLoginFailureHandler.java
@@ -4,17 +4,21 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
-public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+public class FormLoginFailureHandler implements AuthenticationFailureHandler {
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException exception) throws IOException, ServletException {
-        request.getSession().setAttribute("errormessage", exception.getMessage());
+        String errorMessage = "이메일 또는 비밀번호가 올바르지 않습니다.";
+
+        request.getSession().setAttribute("errormessage", errorMessage);
         response.sendRedirect("/users/signin");
     }
 }

--- a/src/main/java/com/fifo/ticketing/domain/user/service/UserFormService.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/service/UserFormService.java
@@ -41,7 +41,7 @@ public class UserFormService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Optional<User> userOptional = userRepository.findByEmail(email);
         User findUser = userOptional.orElseThrow(
-            () -> new UsernameNotFoundException("잘못된 이메일 혹은 비밀번호 입니다.")
+            () -> new ErrorException(ErrorCode.NOT_FOUND_MEMBER)
         );
         return new UserFormDetails(findUser);
     }

--- a/src/main/java/com/fifo/ticketing/domain/user/service/UserFormService.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/service/UserFormService.java
@@ -41,7 +41,7 @@ public class UserFormService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         Optional<User> userOptional = userRepository.findByEmail(email);
         User findUser = userOptional.orElseThrow(
-            () -> new ErrorException(ErrorCode.NOT_FOUND_MEMBER)
+            () -> new UsernameNotFoundException("잘못된 이메일 혹은 비밀번호 입니다.")
         );
         return new UserFormDetails(findUser);
     }

--- a/src/main/java/com/fifo/ticketing/global/config/SecurityConfig.java
+++ b/src/main/java/com/fifo/ticketing/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.fifo.ticketing.global.config;
 
+import com.fifo.ticketing.domain.user.service.FormLoginFailureHandler;
 import com.fifo.ticketing.domain.user.service.FormLoginSuccessHandler;
 import com.fifo.ticketing.domain.user.service.OAuth2LoginFailureHandler;
 import com.fifo.ticketing.domain.user.service.OAuth2LoginSuccessHandler;
@@ -19,6 +20,7 @@ public class SecurityConfig {
 
     private final FormLoginSuccessHandler formLoginSuccessHandler;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final FormLoginFailureHandler formLoginFailureHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
 
     @Bean
@@ -35,7 +37,7 @@ public class SecurityConfig {
                     .usernameParameter("email")
                     .passwordParameter("loginPwd")
                     .successHandler(formLoginSuccessHandler)
-                    .failureUrl("/users/signin?error=true")
+                    .failureHandler(formLoginFailureHandler)
                     .permitAll();
             })
             .logout(logout -> {
@@ -53,9 +55,9 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> {
                 auth.requestMatchers("/index", "/", "/api/**")
                     .permitAll()
-                    .requestMatchers("/users/signin", "/users/login", "/users/signup",
-                        "/oauth/login")
-                    .anonymous()
+                    .requestMatchers("/users/signin/**", "/users/login/**", "/users/signup/**",
+                        "/oauth/login/**")
+                    .permitAll()
                     .requestMatchers("/user/**")
                     .hasAnyAuthority("USER", "ADMIN")
                     .requestMatchers("/admin/**")

--- a/src/main/resources/templates/user/sign_in.html
+++ b/src/main/resources/templates/user/sign_in.html
@@ -90,8 +90,8 @@
     <button class="login-btn" type="submit">로그인<br>버튼</button>
   </form>
 
-  <div th:if="${param.error}">
-    <p style="color: red;" th:text="${param.error}">이메일 또는 비밀번호가 올바르지 않습니다.</p>
+  <div th:if="${errorMessage}">
+    <p style="color: red;" th:text="${errorMessage}"></p>
   </div>
 
   <div th:if="${signupSuccess}">


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

#48 

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)
domain/user/controller/ViewController.java
domain/user/service/OAuth2LoginFailureHandler.java
domain/user/service/FormLoginFailureHandler.java
domain/user/service/UserFormService.java
global/config/SecurityConfig.java

src/main/resources/templates/user/sign_in.html

#### 2. (작업 내용 요약)

로그인 진행 과정에서 예외 처리 필요한 부분이
1. 이미 폼 로그인으로 가입을 진행한 경우 소셜 로그인으로 가입 못하도록
2. 로그인 시 잘못된 이메일, 비밀번호 시 에러 필요
3. 1의 반대의 경우 구글은 문제 없으나 네이버, 카카오는 이메일 정보가 안 나오므로 나중에 서비스 확대간에 scope에 메일을 포함시키는 경우에 적용 가능이 우선적으로 필요하다고 생각했습니다.

![image](https://github.com/user-attachments/assets/7eb7ce40-bc06-44e5-91e3-23eee79e7559)
그에 따라 위의 사진은 폼 방식으로 구글 이메일 등록 후 소셜 로그인 방식으로 구글 로그인 진행하고자 하는 경우 에러 발생이 되며

![image](https://github.com/user-attachments/assets/d3fe0928-a9aa-413b-90f0-25634ac5f1bf)
존재하지 않는 이메일 혹은 잘못된 비밀번호를 입력한 경우 위와 같이 에러 메세지가 띄도록 작업했습니다.

이전에 에러 처리의 경우 파라미터에 에러메세지를 같이 넘기는 방식으로 진행했으나 이 경우 보완성과 좀 더 깔끔한 처리를 위해
![image](https://github.com/user-attachments/assets/13545a37-4d4d-4032-b6b0-577a177d7cd6)
위 사진처럼 failureHandler에서 세션에 에러 메세지 정보를 담고 넘기는 방식으로 진행했습니다.

![image](https://github.com/user-attachments/assets/f6954303-4fe4-4211-bbe3-952ba68017b0)
그리고 해당 에러 처리가 완료 된 후 세션에서 해당 메세지를 삭제하는 방식을 통해 부담을 덜고자 하는 방향으로 진행했습니다.


또한 저희가 컨트롤러를 통해 폼을 이동하는 방식이다 보니 로그인을 한 후에도 /users/signin,  /users/signup 과 같이 로그인, 회원가입으로 이동이 되는 문제가 있었습니다.

![image](https://github.com/user-attachments/assets/7eac3ee0-0889-4ce4-8c21-74ad442fb57d)
그에 따라 request에서 session을 가져 온 후 해당 세션에 user 정보가 있는 경우에는 다시 홈 화면으로 리다이렉트 시키는 구조로 변경했습니다.


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- 공통 유틸에 세션 관련 처리 만들어 주신 부분을 아직 적용을 못했는데 추후  refactor 과정 진행하면서 마저 반영하겠습니다.

<br/>
