### PR TITLE
[feat] 예매 상세 페이지 결제 버튼 추가

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/book/controller/view/BookController.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/controller/view/BookController.java
@@ -35,7 +35,7 @@ public class BookController {
 
     }
 
-    @PostMapping("/complete/{bookId}/payment")
+    @PostMapping("/complete/{bookId}/paid")
     public String completePayment(@PathVariable Long performanceId, @PathVariable Long bookId,
         RedirectAttributes redirectAttributes) {
         bookService.completePayment(bookId);

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
@@ -2,7 +2,7 @@ package com.fifo.ticketing.domain.performance.service;
 
 import com.fifo.ticketing.domain.book.entity.Book;
 import com.fifo.ticketing.domain.book.repository.BookRepository;
-import com.fifo.ticketing.domain.book.service.BookCancelService;
+import com.fifo.ticketing.domain.book.service.BookService;
 import com.fifo.ticketing.domain.like.entity.LikeCount;
 import com.fifo.ticketing.domain.like.repository.LikeCountRepository;
 import com.fifo.ticketing.domain.performance.dto.*;
@@ -50,7 +50,7 @@ public class PerformanceService {
     private final SeatService seatService;
     private final ImageFileService imageFileService;
     private final LikeCountRepository likeCountRepository;
-    private final BookCancelService bookCancelService;
+    private final BookService bookService;
     private final BookRepository bookRepository;
 
 
@@ -177,7 +177,7 @@ public class PerformanceService {
 
         // 3. 예약 삭제
         // books를 변수로 가져온 이유는, books의 유저를 기반으로 메일을 전송하기 위해서입니다.
-        List<Book> books = bookCancelService.cancelAllBook(findPerformance);
+        List<Book> books = bookService.cancelAllBook(findPerformance);
 
         // 4. 좌석 삭제
         // 좌석 삭제 시에 Query로 처리하는 부분 때문에 flush가 됩니다.

--- a/src/main/java/com/fifo/ticketing/domain/user/controller/UserController.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.fifo.ticketing.domain.user.controller;
 
+import com.fifo.ticketing.domain.book.service.BookService;
 import com.fifo.ticketing.domain.performance.dto.LikedPerformanceDto;
 import com.fifo.ticketing.domain.user.dto.SessionUser;
 import com.fifo.ticketing.domain.user.service.MyPageService;
@@ -8,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final MyPageService myPageService;
+    private final BookService bookService;
 
     @GetMapping("/users/likes")
     public Page<LikedPerformanceDto> getUserLikes(HttpSession session,
@@ -28,5 +33,11 @@ public class UserController {
         return myPageService.getUserLikedPerformance(
             userId, pageable
         );
+    }
+
+    @PostMapping("/users/books/{bookId}/paid")
+    public ResponseEntity<?> completePayment(@PathVariable Long bookId) {
+        bookService.completePayment(bookId);
+        return ResponseEntity.ok("결제가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/fifo/ticketing/domain/user/controller/UserController.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.fifo.ticketing.domain.performance.dto.LikedPerformanceDto;
 import com.fifo.ticketing.domain.user.dto.SessionUser;
 import com.fifo.ticketing.domain.user.service.MyPageService;
 import jakarta.servlet.http.HttpSession;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,6 +39,10 @@ public class UserController {
     @PostMapping("/users/books/{bookId}/paid")
     public ResponseEntity<?> completePayment(@PathVariable Long bookId) {
         bookService.completePayment(bookId);
-        return ResponseEntity.ok("결제가 완료되었습니다.");
+        return ResponseEntity.ok(Map.of(
+            "status", "success",
+            "bookId", bookId,
+            "message", "결제가 완료되었습니다!"
+        ));
     }
 }

--- a/src/main/resources/templates/book/detail.html
+++ b/src/main/resources/templates/book/detail.html
@@ -157,6 +157,7 @@
         <input type="hidden" name="bookId" th:value="${bookDetail.bookId}" />
         <button type="submit" class="btn">예매 취소</button>
       </form>
+      <button th:onclick="|completePayment(${bookDetail.bookId})|" class="btn">결제하기</button>
     </div>
   </div>
 </div>
@@ -165,6 +166,28 @@
 <script>
   function confirmCancel() {
     return confirm("정말 예매를 취소하시겠습니까?");
+  }
+
+  function completePayment(bookId) {
+    fetch(`/users/books/${bookId}/paid`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      }
+    })
+    .then(async (response) => {
+      const data = await response.json();
+
+      if (response.ok && data.status === 'success') {
+        alert(`결제가 완료되었습니다!`);
+        window.location.reload();
+      } else {
+        throw new Error(data.message || '결제 실패');
+      }
+    })
+    .catch(error => {
+      alert('결제 중 오류가 발생했습니다: ' + error.message);
+    });
   }
 </script>
 

--- a/src/main/resources/templates/book/detail.html
+++ b/src/main/resources/templates/book/detail.html
@@ -98,6 +98,10 @@
       display: flex;
       justify-content: flex-end;
     }
+
+    tbody tr:hover {
+      background-color: #f0f8ff;
+    }
   </style>
 </head>
 <body>
@@ -123,10 +127,9 @@
       </tr>
       </thead>
       <tbody>
-      <tr>
-        <td>
-          <a th:href="@{'/performances/' + ${bookDetail.performanceId}}" th:text="${bookDetail.performanceTitle}"></a>
-        </td>
+      <tr th:onclick="|window.location.href='/performances/${bookDetail.performanceId}'|"
+          style="cursor: pointer;">
+        <td th:text="${bookDetail.performanceTitle}"></td>
         <td th:text="${bookDetail.placeName}"></td>
         <td>
           <ul>

--- a/src/main/resources/templates/book/detail.html
+++ b/src/main/resources/templates/book/detail.html
@@ -160,7 +160,8 @@
         <input type="hidden" name="bookId" th:value="${bookDetail.bookId}" />
         <button type="submit" class="btn">예매 취소</button>
       </form>
-      <button th:onclick="|completePayment(${bookDetail.bookId})|" class="btn">결제하기</button>
+      <button th:if="${bookDetail.bookStatus.name() == 'CONFIRMED'}"
+              th:onclick="|completePayment(${bookDetail.bookId})|" class="btn">결제하기</button>
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/user/bookList.html
+++ b/src/main/resources/templates/user/bookList.html
@@ -74,12 +74,20 @@
     a:hover {
       text-decoration: underline;
     }
+
+    .reservation-card:hover {
+      background-color: #f0f8ff;
+    }
   </style>
 </head>
 <body>
 <h2>예매 목록</h2>
 
-<div th:each="book : ${bookedList}" class="reservation-card">
+<div th:each="book : ${bookedList}"
+     class="reservation-card"
+     th:onclick="|window.location.href='/users/books/${book.bookId}'|"
+     style="cursor: pointer;">
+
   <img th:src="@{/image/{fileName}(fileName=${book.encodedFileName})}" alt="공연 포스터"/>
 
   <div class="reservation-info">
@@ -96,9 +104,7 @@
       </thead>
       <tbody>
       <tr>
-        <td>
-          <a th:href="@{'/users/books/' + ${book.bookId}}" th:text="${book.performanceTitle}"></a>
-        </td>
+        <td th:text="${book.performanceTitle}"></td>
         <td th:text="${book.placeName}"></td>
         <td>
           <ul>


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#68 

사용자 예매 상세 페이지에서 결제 버튼을 추가하였습니다.

#### 1. (작업 파일)

- book/controller/view/BookController.java
- user/controller/UserController.java
- templates/book/detail.html
- templates/user/bookList.html

#### 2. (작업 내용 요약)

**결제 버튼**
![스크린샷 2025-05-15 102051](https://github.com/user-attachments/assets/6e21bb38-edbe-46b8-9682-887d9964665b)

<br/>

**결제 완료**
![스크린샷 2025-05-15 102103](https://github.com/user-attachments/assets/a82fe395-8ccc-4a85-ac89-057f1e78b16b)

<br/>

**버튼 비활성화**
![스크린샷 2025-05-15 102325](https://github.com/user-attachments/assets/0e0b0eb6-9f98-47c7-87bb-c06d008d26bb)

- 결제가 진행되면 페이지가 reload 되고, 버튼이 비활성화 됩니다.

<br/>

추가적으로 기존엔 사용자 예매 목록과 예매 상세 조회 페이지에서 공연명을 눌러야 다음 페이지로 이동되었습니다.
이를 공연명 클릭이 아닌 해당 테이블 클릭하면 이동되도록 수정하였습니다~

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->


<br/>
