### PR TITLE
[feat] 알림메일 비동기 전송

### DIFF
--- a/src/main/java/com/fifo/ticketing/TicketingApplication.java
+++ b/src/main/java/com/fifo/ticketing/TicketingApplication.java
@@ -4,11 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableAsync
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableScheduling
 
 public class TicketingApplication {
 

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
@@ -10,13 +10,17 @@ import com.fifo.ticketing.domain.like.repository.LikeRepository;
 import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.user.entity.User;
+import com.fifo.ticketing.global.Event.LikeMailEvent;
 import com.fifo.ticketing.global.exception.ErrorException;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
 @Service
@@ -26,6 +30,9 @@ public class LikeMailNotificationService {
     private final LikeRepository likeRepository;
     private final LikeMailService likeMailService;
     private final PerformanceRepository performanceRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+
 
     @Transactional
     public boolean sendLikeNotification(Long performanceId) {
@@ -76,7 +83,8 @@ public class LikeMailNotificationService {
             User user = like.getUser();
             Performance performance = like.getPerformance();
 
-            likeMailService.performanceStart(user, performance);
+            eventPublisher.publishEvent(new LikeMailEvent(user, performance));
+            //likeMailService.performanceStart(user, performance);
 
         }
 

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -16,6 +17,7 @@ public class LikeMailService {
     @Value("${spring.mail.username}")
     private String fromAddress;
 
+    @Async("mailExecutor")
     public void performanceStart(User user, Performance performance){
         SimpleMailMessage message = new SimpleMailMessage();
 

--- a/src/main/java/com/fifo/ticketing/global/Event/LikeMailEvent.java
+++ b/src/main/java/com/fifo/ticketing/global/Event/LikeMailEvent.java
@@ -1,0 +1,16 @@
+package com.fifo.ticketing.global.Event;
+
+import com.fifo.ticketing.domain.performance.entity.Performance;
+import com.fifo.ticketing.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+
+@Getter
+@AllArgsConstructor
+public class LikeMailEvent {
+    private final User user;
+    private final Performance performance;
+
+}

--- a/src/main/java/com/fifo/ticketing/global/Event/LikeMailEventListener.java
+++ b/src/main/java/com/fifo/ticketing/global/Event/LikeMailEventListener.java
@@ -1,0 +1,23 @@
+package com.fifo.ticketing.global.Event;
+
+import com.fifo.ticketing.domain.like.service.LikeMailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+
+@Component
+@RequiredArgsConstructor
+public class LikeMailEventListener {
+
+    private final LikeMailService likeMailService;
+
+
+    @Async("mailExecutor")
+    @TransactionalEventListener
+    public void HandleLikeMailEvent(LikeMailEvent event) {
+        likeMailService.performanceStart(event.getUser() , event.getPerformance());
+    }
+}

--- a/src/main/java/com/fifo/ticketing/global/config/AsyncConfig.java
+++ b/src/main/java/com/fifo/ticketing/global/config/AsyncConfig.java
@@ -1,0 +1,31 @@
+package com.fifo.ticketing.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync  //비동기 처리 활성화
+public class AsyncConfig implements AsyncConfigurer {
+
+
+    //커스텀 쓰레드 풀 정의
+    @Override
+    @Bean(name = "mailExecutor")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.initialize();
+
+        return executor;
+    }
+
+
+
+}

--- a/src/test/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationServiceTest.java
+++ b/src/test/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationServiceTest.java
@@ -1,7 +1,9 @@
 package com.fifo.ticketing.domain.like.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -9,6 +11,9 @@ import com.fifo.ticketing.domain.like.repository.LikeRepository;
 import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.user.entity.User;
+import com.fifo.ticketing.global.Event.LikeMailEvent;
+import com.fifo.ticketing.global.Event.LikeMailEventListener;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +21,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+
 
 class LikeMailNotificationServiceTest {
 
@@ -30,6 +39,10 @@ class LikeMailNotificationServiceTest {
 
     @Mock
     private LikeMailService likeMailService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
 
     private Performance performance;
     private final Long performanceId = 100L;
@@ -56,6 +69,27 @@ class LikeMailNotificationServiceTest {
         boolean result = likeMailNotificationService.sendLikeNotification(performanceId);
 
         assertThat(result).isTrue();
+        verify(likeMailService).performanceStart(user, performance);
+    }
+
+    @Test
+    void 이벤트_리스너테스트() {
+        // given
+        User user = User.builder()
+            .email("test@email.com")
+            .username("테스트")
+            .build();
+
+        Performance performance = Performance.builder()
+            .title("테스트 공연")
+            .build();
+
+        LikeMailEvent event = new LikeMailEvent(user, performance);
+
+        // when: 이벤트 리스너 직접 호출
+        new LikeMailEventListener(likeMailService).HandleLikeMailEvent(event);
+
+        // then
         verify(likeMailService).performanceStart(user, performance);
     }
 }


### PR DESCRIPTION

## ✨ 설명
#63 알림 메일 전송을 비동기 처리

알림메일 비동기 전송

#### 1. (작업 파일)

TicketingApplication.java
LikeMailNotificationService.java
LikeMailService.java
LikeMailEvent.java
LikeMailEventListener.java
AsyncConfig.java
LikeMailNotificationServiceTest.java
#### 2. (작업 내용 요약)

(작업한 부분 설명 및 코드와 이미지 첨부)
![image](https://github.com/user-attachments/assets/ce2272ad-92cb-4c92-a0b0-c57686f9d515)
AsyncConfig 설정 추가 (mailExecutor 등록)
LikeMailEvent 생성 및 도메인 이벤트 클래스로 활용

![image](https://github.com/user-attachments/assets/7b0ab732-cda5-4ef1-af0e-42db368febab)
LikeMailEventListener 작성 후, LikeMailService.performanceStart() 비동기 호출

![image](https://github.com/user-attachments/assets/9b5f2bb6-bd72-4d60-9e2b-129186bc966f)
기존 likeMailService.performanceStart(user, performance);에서 eventPublisher.publishEvent(new LikeMailEvent(user, performance)); 로 변경







