### PR TITLE
[fix] 좌석 예매 시 동시성 문제를 낙관적 락으로 해소

### DIFF
--- a/src/main/java/com/fifo/ticketing/TicketingApplication.java
+++ b/src/main/java/com/fifo/ticketing/TicketingApplication.java
@@ -2,7 +2,6 @@ package com.fifo.ticketing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -12,7 +11,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
-
 public class TicketingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/fifo/ticketing/domain/book/repository/BookSeatRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/repository/BookSeatRepository.java
@@ -9,4 +9,8 @@ import org.springframework.data.repository.query.Param;
 public interface BookSeatRepository extends JpaRepository<BookSeat, Long> {
 
     List<BookSeat> findAllByBookId(Long bookId);
+
+    @Query("SELECT bs FROM BookSeat bs JOIN FETCH bs.seat WHERE bs.book.id = :bookId")
+    List<BookSeat> findAllByBookIdWithSeat(@Param("bookId") Long bookId);
+
 }

--- a/src/main/java/com/fifo/ticketing/domain/book/service/BookScheduleManager.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/service/BookScheduleManager.java
@@ -8,7 +8,6 @@ import com.fifo.ticketing.domain.book.mapper.BookMapper;
 import com.fifo.ticketing.domain.book.repository.BookRepository;
 import com.fifo.ticketing.domain.book.repository.BookScheduleRepository;
 import com.fifo.ticketing.domain.book.repository.BookSeatRepository;
-import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.seat.entity.Seat;
 import com.fifo.ticketing.global.exception.ErrorCode;
 import com.fifo.ticketing.global.exception.ErrorException;
@@ -58,7 +57,7 @@ public class BookScheduleManager {
 
             log.info("{}번 예매 취소됨", bookId);
 
-            List<BookSeat> bookSeats = bookSeatRepository.findAllByBookId(book.getId());
+            List<BookSeat> bookSeats = bookSeatRepository.findAllByBookIdWithSeat(book.getId());
             for (BookSeat bookSeat : bookSeats) {
                 Seat seat = bookSeat.getSeat();
                 seat.available();

--- a/src/main/java/com/fifo/ticketing/domain/book/service/BookService.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/service/BookService.java
@@ -2,6 +2,7 @@ package com.fifo.ticketing.domain.book.service;
 
 import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_MEMBER;
 import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCE;
+import static com.fifo.ticketing.global.exception.ErrorCode.SEAT_ALREADY_BOOKED;
 
 import com.fifo.ticketing.domain.book.dto.BookCompleteDto;
 import com.fifo.ticketing.domain.book.dto.BookCreateRequest;
@@ -27,6 +28,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,14 +55,24 @@ public class BookService {
         Performance performance = performanceRepository.findById(performanceId)
             .orElseThrow(() -> new ErrorException(NOT_FOUND_PERFORMANCE));
 
-        List<Seat> selectedSeats = seatRepository.findAllById(request.getSeatIds());
+//        List<Seat> selectedSeats = seatRepository.findAllById(request.getSeatIds());
+        List<Seat> selectedSeats = seatRepository.findAllByIdInWithOptimisticLock(
+                request.getSeatIds());
 
         for (Seat seat : selectedSeats) {
             if (!seat.getSeatStatus().equals(SeatStatus.AVAILABLE)) {
                 throw new AlertDetailException(ErrorCode.SEAT_ALREADY_BOOKED,
                     String.format("%d번 좌석은 이미 예약되었습니다.", seat.getId()));
             }
+            seat.book();
         }
+
+        try {
+            seatRepository.flush();
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new ErrorException(SEAT_ALREADY_BOOKED);
+        }
+
         int totalPrice = selectedSeats.stream().mapToInt(Seat::getPrice).sum();
         int quantity = selectedSeats.size();
 
@@ -72,13 +84,9 @@ public class BookService {
 
         bookSeatRepository.saveAll(bookSeatList);
 
-        for (Seat seat : selectedSeats) {
-            seat.book();
-        }
-
         Long bookId = book.getId();
 
-        LocalDateTime runTime = LocalDateTime.now().plusMinutes(5);
+        LocalDateTime runTime = LocalDateTime.now().plusMinutes(10);
 
         bookScheduleManager.scheduleCancelTask(bookId, runTime);
 

--- a/src/main/java/com/fifo/ticketing/domain/seat/entity/Seat.java
+++ b/src/main/java/com/fifo/ticketing/domain/seat/entity/Seat.java
@@ -13,7 +13,6 @@ import org.hibernate.annotations.BatchSize;
 @Getter
 @Table(name = "seats")
 @NoArgsConstructor
-@AllArgsConstructor
 @BatchSize(size = 100)
 public class Seat extends BaseDateEntity {
 
@@ -39,6 +38,8 @@ public class Seat extends BaseDateEntity {
     @Column(nullable = false)
     private SeatStatus seatStatus;
 
+    @Version
+    private Long version;
 
     public void book() {
         this.seatStatus = SeatStatus.BOOKED;
@@ -52,7 +53,19 @@ public class Seat extends BaseDateEntity {
         this.seatStatus = SeatStatus.OCCUPIED;
     }
 
+    // Version의 경우는 JPA가 Persist 시에 자동으로 생성하기 때문에 생성자에 추가하지 않아도 됩니다!
+    public Seat(Long id, Performance performance, String seatNumber, Integer price,
+            Grade grade, SeatStatus seatStatus) {
+        this.id = id;
+        this.performance = performance;
+        this.seatNumber = seatNumber;
+        this.price = price;
+        this.grade = grade;
+        this.seatStatus = seatStatus;
+    }
+
     public static Seat of(Performance performance, Grade grade, int number) {
-        return new Seat(null, performance, grade.getGrade() + number, grade.getDefaultPrice(), grade, SeatStatus.AVAILABLE);
+        return new Seat(null, performance, grade.getGrade() + number, grade.getDefaultPrice(),
+                grade, SeatStatus.AVAILABLE);
     }
 }

--- a/src/main/java/com/fifo/ticketing/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/seat/repository/SeatRepository.java
@@ -3,8 +3,10 @@ package com.fifo.ticketing.domain.seat.repository;
 import com.fifo.ticketing.domain.seat.entity.Seat;
 
 import com.fifo.ticketing.domain.seat.entity.SeatStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +23,8 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Seat s SET s.seatStatus = :status WHERE s.performance.id = :performanceId")
     void updateSeatStatusByPerformanceId(@Param("performanceId") Long performanceId, @Param("status") SeatStatus status);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT s FROM Seat s WHERE s.id IN :seatIds")
+    List<Seat> findAllByIdInWithOptimisticLock(@Param("seatIds") List<Long> seatIds);
 }

--- a/src/main/java/com/fifo/ticketing/global/config/SecurityConfig.java
+++ b/src/main/java/com/fifo/ticketing/global/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                     .requestMatchers("/user/**")
                     .hasAnyAuthority("USER", "ADMIN")
                     .requestMatchers("/admin/**")
-                    .hasAnyAuthority("USER", "ADMIN")
+                    .hasAnyAuthority("ADMIN")
                     .anyRequest()
                     .permitAll();
             })

--- a/src/main/resources/templates/book/complete.html
+++ b/src/main/resources/templates/book/complete.html
@@ -131,7 +131,7 @@
 
     <div>
       <form th:if="${!book.paymentCompleted}"
-            th:action="@{'/performances/' + ${book.performanceId} + '/book/complete/' + ${bookId} + '/payment'}"
+            th:action="@{'/performances/' + ${book.performanceId} + '/book/complete/' + ${bookId} + '/paid'}"
             method="post">
         <button type="submit" class="btn">결제하기</button>
       </form>


### PR DESCRIPTION
[[fix] 좌석 예매 시 동시성 문제를 낙관적 락으로 해소](https://github.com/prgrms-be-devcourse/NBE5-7-2-Team01/issues/56) #56 

## ✨ 설명

좌석 예매 시, 동시성 문제가 발생할 수 있는 부분을 낙관적 락 (optimistic lock)으로 해소하였습니다.

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)

- BookSeatRepository.java
- BookScheduleManager.java
- BookService.java
- Seat.java
- SeatRepository.java
- securityConfig.java
- complete.html

#### 2. (작업 내용 요약)

- Seat.java
```java
    @Version
    private Long version;

    public Seat(Long id, Performance performance, String seatNumber, Integer price,
            Grade grade, SeatStatus seatStatus) {
        this.id = id;
        this.performance = performance;
        this.seatNumber = seatNumber;
        this.price = price;
        this.grade = grade;
        this.seatStatus = seatStatus;
    }
```
Seat에 version을 추가하였고, version의 경우 JPA에서 관리해야 하는 것이기 때문에, 
`AllArgsConstructor`를 제외하고, 따로 생성자를 추가하였습니다.

- SeatRepository.java
```java
    @Lock(LockModeType.OPTIMISTIC)
    @Query("SELECT s FROM Seat s WHERE s.id IN :seatIds")
    List<Seat> findAllByIdInWithOptimisticLock(@Param("seatIds") List<Long> seatIds);
```
JPQL을 이용해서 명시적으로 LOCK을 걸어주는 쿼리 메서드를 추가하였습니다.
좌석 조회시, LockModeType.OPTIMISTIC으로 낙관적 락을 적용하였습니다.

complete.html
```html
th:action="@{'/performances/' + ${book.performanceId} + '/book/complete/' + ${bookId} + '/paid'}"
```

API Controller의 URL에 맞춰서 수정하였습니다.

BookSeatRepository.java
```java
@Query("SELECT bs FROM BookSeat bs JOIN FETCH bs.seat WHERE bs.book.id = :bookId")
    List<BookSeat> findAllByBookIdWithSeat(@Param("bookId") Long bookId);
```

- 비동기 스케쥴러에서 이용하는 데이터는 트랜잭션 내에서 미리 로딩해야한다고 합니다.
- Seat의 경우 Lazy 로딩이기 때문에 해당 부분을 Fetch Join하여 함께 조회하였습니다.

1. A 유저가 좌석을 선택

<img width="802" alt="스크린샷 2025-05-16 10 31 23" src="https://github.com/user-attachments/assets/9a4b07e0-2ae1-4572-a184-2175c54babcd" />

2. B 유저가 A 유저와 동일한 좌석을 선택

<img width="1604" alt="스크린샷 2025-05-16 10 31 16" src="https://github.com/user-attachments/assets/ad853899-cb24-4a27-9529-87a9adaa2f0a" />


3. A 유저가 선택한 좌석을 예매합니다.

<img width="780" alt="스크린샷 2025-05-16 10 31 46" src="https://github.com/user-attachments/assets/e2fecc1e-9659-47c8-95ca-fff13c210d4a" />

4. B 유저도 바로 선택한 좌석을 예매합니다.
<img width="1604" alt="스크린샷 2025-05-16 10 31 44" src="https://github.com/user-attachments/assets/47d6187d-bb62-4523-afb6-826e68aed86f" />

```java
        try {
            seatRepository.flush();
        } catch (ObjectOptimisticLockingFailureException e) {
            throw new ErrorException(SEAT_ALREADY_BOOKED);
        }
```

이 때, 좌석 번호로 예외가 출력되는 것이 아니라, `해당 좌석은 이미 예약되었습니다.`라는 예외가 발생한 것으로,
flush 시점에서 동시성 락으로 인해 예외가 발생한 것을 알 수 있습니다.

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- (리뷰 받고 싶거나 알리고 싶은 내용)

<br/>
