### PR TITLE
[feat, refactor] 1시간 후에 미결제 유저에게 알림 스케줄링

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/repository/BookRepository.java
@@ -1,6 +1,7 @@
 package com.fifo.ticketing.domain.book.repository;
 
 import com.fifo.ticketing.domain.book.entity.Book;
+import com.fifo.ticketing.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,4 +31,6 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     void cancelAllByPerformance(@Param("performance") Performance performance,
             @Param("cancelStatus") BookStatus cancelStatus,
             @Param("currentStatus") BookStatus currentStatus);
+
+    boolean existsByUserAndPerformanceAndBookStatus(User user, Performance performance, BookStatus bookStatus);
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
@@ -75,10 +75,13 @@ public class LikeMailNotificationService {
         List<Like> likes = likeRepository.findLikesByTargetTime(start , end);
 
         for (Like like : likes) {
-            User user = like.getUser();
-            Performance performance = like.getPerformance();
+            if (like.isLiked()){
+                User user = like.getUser();
+                Performance performance = like.getPerformance();
 
-            eventPublisher.publishEvent(new LikeMailEvent(user, performance));
+                eventPublisher.publishEvent(new LikeMailEvent(user, performance));
+            }
+
             //likeMailService.performanceStart(user, performance);
 
         }

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationService.java
@@ -2,12 +2,15 @@ package com.fifo.ticketing.domain.like.service;
 
 import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PERFORMANCES;
 
+import com.fifo.ticketing.domain.book.entity.BookStatus;
+import com.fifo.ticketing.domain.book.repository.BookRepository;
 import com.fifo.ticketing.domain.like.entity.Like;
 import com.fifo.ticketing.domain.like.repository.LikeRepository;
 import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.user.entity.User;
 import com.fifo.ticketing.global.event.LikeMailEvent;
+import com.fifo.ticketing.global.event.MailType;
 import com.fifo.ticketing.global.exception.ErrorException;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -26,7 +29,7 @@ public class LikeMailNotificationService {
     private final LikeMailService likeMailService;
     private final PerformanceRepository performanceRepository;
     private final ApplicationEventPublisher eventPublisher;
-
+    private final BookRepository bookRepository;
 
 
     @Transactional
@@ -79,13 +82,42 @@ public class LikeMailNotificationService {
                 User user = like.getUser();
                 Performance performance = like.getPerformance();
 
-                eventPublisher.publishEvent(new LikeMailEvent(user, performance));
+                eventPublisher.publishEvent(new LikeMailEvent(user, performance, MailType.RESERVATION_NOTICE));
             }
 
             //likeMailService.performanceStart(user, performance);
 
         }
 
+    }
+
+    @Transactional
+    public void sendNoPayedNotification() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime reservationTime = now.minusMinutes(60);
+
+        // 정각으로 하면 안보내는 문제가 있어 +- 1분의 시간을 주었습니다.
+        LocalDateTime start = reservationTime.minusMinutes(1);
+        LocalDateTime end = reservationTime.plusMinutes(1);
+
+        List<Like> likes = likeRepository.findLikesByTargetTime(start, end);
+
+        for (Like like : likes) {
+
+            if (like.isLiked()) {
+                User user = like.getUser();
+                Performance performance = like.getPerformance();
+
+                boolean payed = bookRepository.existsByUserAndPerformanceAndBookStatus(user, performance, BookStatus.PAYED);
+                log.info("{}", payed);
+                if (!payed) {
+                    eventPublisher.publishEvent(
+                        new LikeMailEvent(user, performance, MailType.NO_PAYED));
+                }
+
+            }
+
+        }
     }
 
 }

--- a/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailService.java
+++ b/src/main/java/com/fifo/ticketing/domain/like/service/LikeMailService.java
@@ -1,6 +1,7 @@
 package com.fifo.ticketing.domain.like.service;
 
 import com.fifo.ticketing.domain.performance.entity.Performance;
+import com.fifo.ticketing.domain.seat.repository.SeatRepository;
 import com.fifo.ticketing.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class LikeMailService {
     private final JavaMailSender javaMailSender;
+    private final SeatRepository seatRepository;
 
     @Value("${spring.mail.username}")
     private String fromAddress;
@@ -29,6 +31,24 @@ public class LikeMailService {
         //이메일 내용
         message.setText(user.getUsername()+"님 좋아요를 눌러주신 공연 "+ performance.getTitle()+"의 티켓팅 시작이 30분 남았습니다."+
         "감사합니다");
+
+        javaMailSender.send(message);
+
+    }
+
+    @Async("mailExecutor")
+    public void NoPayedPerformance(User user, Performance performance){
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setFrom(fromAddress);
+        //이메일 제목
+        message.setSubject(performance.getTitle()+"의 티켓팅 시작이 1시간 지났습니다.");
+        //이메일 받을 대상
+        message.setTo(user.getEmail());
+        //이메일 내용
+        message.setText(user.getUsername()+"님 좋아요를 눌러주신 공연 "+ performance.getTitle()+"의 좌석이" +
+            seatRepository.countAvailableSeatsByPerformanceId(performance.getId()) +"개 남았습니다."+
+            "감사합니다");
 
         javaMailSender.send(message);
 

--- a/src/main/java/com/fifo/ticketing/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/seat/repository/SeatRepository.java
@@ -21,4 +21,8 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Seat s SET s.seatStatus = :status WHERE s.performance.id = :performanceId")
     void updateSeatStatusByPerformanceId(@Param("performanceId") Long performanceId, @Param("status") SeatStatus status);
+
+    //공연의 남은 좌석 수 계산
+    @Query("select count(*) From Seat s where s.performance.id = :performanceId AND s.seatStatus = 'AVAILABLE'")
+    int countAvailableSeatsByPerformanceId(@Param("performanceId") Long performanceId);
 }

--- a/src/main/java/com/fifo/ticketing/global/event/LikeMailEvent.java
+++ b/src/main/java/com/fifo/ticketing/global/event/LikeMailEvent.java
@@ -12,5 +12,6 @@ import lombok.Getter;
 public class LikeMailEvent {
     private final User user;
     private final Performance performance;
+    private final MailType mailType;
 
 }

--- a/src/main/java/com/fifo/ticketing/global/event/LikeMailEventListener.java
+++ b/src/main/java/com/fifo/ticketing/global/event/LikeMailEventListener.java
@@ -2,9 +2,9 @@ package com.fifo.ticketing.global.event;
 
 import com.fifo.ticketing.domain.like.service.LikeMailService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 
 @Component
@@ -15,8 +15,14 @@ public class LikeMailEventListener {
 
 
     @Async("mailExecutor")
-    @TransactionalEventListener
-    public void HandleLikeMailEvent(LikeMailEvent event) {
-        likeMailService.performanceStart(event.getUser() , event.getPerformance());
+    @EventListener
+    public void handleLikeMailEvent(LikeMailEvent event) {
+        switch (event.getMailType()){
+            case NO_PAYED -> likeMailService.NoPayedPerformance(event.getUser() , event.getPerformance());
+            case RESERVATION_NOTICE -> likeMailService.performanceStart(event.getUser() , event.getPerformance());
+        }
+
     }
+
+
 }

--- a/src/main/java/com/fifo/ticketing/global/event/MailType.java
+++ b/src/main/java/com/fifo/ticketing/global/event/MailType.java
@@ -1,0 +1,7 @@
+package com.fifo.ticketing.global.event;
+
+public enum MailType {
+
+    NO_PAYED,
+    RESERVATION_NOTICE;
+}

--- a/src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.java
@@ -18,4 +18,8 @@ public class NotificationScheduler {
     }
 
 
+    @Scheduled(cron = "0 0 * * * *")
+    public void NoPayedNotification(){
+        likeMailNotificationService.sendNoPayedNotification();
+    }
 }

--- a/src/test/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationServiceTest.java
+++ b/src/test/java/com/fifo/ticketing/domain/like/service/LikeMailNotificationServiceTest.java
@@ -12,6 +12,7 @@ import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.user.entity.User;
 import com.fifo.ticketing.global.event.LikeMailEvent;
 import com.fifo.ticketing.global.event.LikeMailEventListener;
+import com.fifo.ticketing.global.event.MailType;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,10 +83,10 @@ class LikeMailNotificationServiceTest {
             .title("테스트 공연")
             .build();
 
-        LikeMailEvent event = new LikeMailEvent(user, performance);
+        LikeMailEvent event = new LikeMailEvent(user, performance, MailType.RESERVATION_NOTICE);
 
         // when: 이벤트 리스너 직접 호출
-        new LikeMailEventListener(likeMailService).HandleLikeMailEvent(event);
+        new LikeMailEventListener(likeMailService).handleLikeMailEvent(event);
 
         // then
         verify(likeMailService).performanceStart(user, performance);


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명



#### 1. (작업 파일)

BookRepository.java
LikeMailNotificationService.java
LikeMailService.java
SeatRepository.java
LikeMailEvent.java
LikeMailEventListener.java
MailType.java
NotificationScheduler.java

#### 2. (작업 내용 요약)

[Refactor] 
한 이벤트에 다른 메일을 보내기 위해 이벤트 객체에 타입 추가
(작업한 부분 설명 및 코드와 이미지 첨부)

![image](https://github.com/user-attachments/assets/3d71c07e-3164-48f0-b378-19e70095db4b)
![image](https://github.com/user-attachments/assets/b6252c0e-ebc6-4486-8015-758be3556015)

![image](https://github.com/user-attachments/assets/451d7f5d-9981-4a71-a961-f4620eea4a32)
like 상태일때만 보낸다는 부분이 빠져 있어 추가 했습니다.

feat 
![image](https://github.com/user-attachments/assets/9ab75760-d469-4f02-8eea-35d516099e39)
한시간 후에 보내질 메일

리포지토리
![image](https://github.com/user-attachments/assets/500196dd-9c17-4b8f-836b-cf70b3815b53)
결제했는지 확인 메서드
![image](https://github.com/user-attachments/assets/6d33b6d6-4a0f-4936-a37d-52c3b113836d)
남은 좌석 확인

![image](https://github.com/user-attachments/assets/420ed5f0-77eb-44a2-a54d-070b80cddadb)
스케줄러 확인 후
![image](https://github.com/user-attachments/assets/ddc8dd30-0bd3-494d-acd2-cb7110dece63)

서비스 작성
<br/>
![image](https://github.com/user-attachments/assets/2e194b3d-7241-45a6-a12b-2377b8ee205e)
메일 전송되는것 또한 확인 했습니다.

## 💬 리뷰
일단 기존에 좋아요한 상태라는 부분이 빠져 있어다는 것을 발견하여 추가 하였습니다.

한 이벤트 리스터에 계속 다른 메일을 보내기 위해 타입을 분리해 보았습니다. 이 부분에 대해 어떻게 생각하시나요
--------------------
리버트 한부분 다시 올립니다.😅