### PR TITLE
[feat, style] 공연 제목으로 검색, 카테고리 <select> display 속성 수정

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
@@ -50,6 +50,22 @@ public class PerformanceController {
         return "/performance/view_performances";
     }
 
+    @GetMapping(params = {"search"})
+    public String searchPerformances(
+        HttpSession session,
+        @RequestParam(value = "search", defaultValue = "", required = false) String keyword,
+        @RequestParam(value = "page", defaultValue = "0", required = false) int page,
+        @RequestParam(value = "size", defaultValue = "10", required = false) int size,
+        Model model) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<PerformanceResponseDto> performances = performanceService.searchPerformancesByKeyword(
+            keyword, pageable);
+        String baseQuery = "?search=" + keyword + "&size=" + size;
+
+        preparedModel(session, model, performances, page, baseQuery);
+        return "/performance/view_performances";
+    }
+
     @GetMapping(params = {"sort"})
     public String viewPerformancesSortedBy(
         HttpSession session,

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
@@ -18,6 +18,19 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     @EntityGraph(attributePaths = {"file"})
     @Query(
         value = "SELECT p FROM Performance p " +
+            "WHERE p.startTime > :now " + " AND p.deletedFlag = false "
+            + "AND p.title LIKE CONCAT('%', :keyword, '%') " +
+            "ORDER BY p.reservationStartTime ASC, p.startTime ASC",
+        countQuery = "SELECT COUNT(p) FROM Performance p " +
+            "WHERE p.startTime > :now AND p.deletedFlag = false " +
+            "AND p.title LIKE CONCAT('%', :keyword, '%') "
+    )
+    Page<Performance> findUpcomingPerformancesByKeywordContaining(@Param("now") LocalDateTime now,
+        @Param("keyword") String keyword, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"file"})
+    @Query(
+        value = "SELECT p FROM Performance p " +
             "WHERE p.startTime > :now AND p.deletedFlag = false " +
             "ORDER BY p.reservationStartTime ASC, p.startTime ASC",
         countQuery = "SELECT COUNT(p) FROM Performance p WHERE p.startTime > :now"

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceService.java
@@ -29,8 +29,8 @@ import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
 import com.fifo.ticketing.domain.performance.repository.PlaceRepository;
 import com.fifo.ticketing.domain.seat.entity.Seat;
 import com.fifo.ticketing.domain.seat.service.SeatService;
-import com.fifo.ticketing.global.event.PerformanceCanceledEvent;
 import com.fifo.ticketing.global.entity.File;
+import com.fifo.ticketing.global.event.PerformanceCanceledEvent;
 import com.fifo.ticketing.global.exception.ErrorException;
 import com.fifo.ticketing.global.util.ImageFileService;
 import java.io.IOException;
@@ -263,6 +263,17 @@ public class PerformanceService {
         } catch (RuntimeException e) {
             throw new ErrorException(SEAT_CREATE_FAILED);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PerformanceResponseDto> searchPerformancesByKeyword(String keyword,
+        Pageable pageable) {
+        if (keyword == null || keyword.isEmpty()) {
+            getPerformancesSortedByLatest(pageable);
+        }
+        Page<Performance> performances = performanceRepository.findUpcomingPerformancesByKeywordContaining(
+            LocalDateTime.now(), keyword, pageable);
+        return PerformanceMapper.toPagePerformanceResponseDto(performances, urlPrefix);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/templates/performance/view_performances.html
+++ b/src/main/resources/templates/performance/view_performances.html
@@ -108,8 +108,8 @@
           <input class="form-check-input" type="radio" name="filter" id="category" value="category">
           <label class="form-check-label" for="category">카테고리</label>
           <select id="categorySelect" class="ml-2" style="display: inline;">
+            <option value="" disabled selected>선택</option>
             <option th:each="category : ${categories}" th:value="${category}" th:text="${category}">
-              선택
             </option>
           </select>
         </div>
@@ -130,78 +130,78 @@
           </label>
         </div>
         <button type="submit" class="custom-button mt-3">조회</button>
-      </form>
-    </div>
+    </form>
+  </div>
 
-    <div class="performance-table">
-      <table class="table table-striped">
-        <thead>
-        <tr>
-          <th>Image</th>
-          <th>Title</th>
-          <th>Category</th>
-          <th>Place</th>
-          <th>Start Time</th>
-          <th>End Time</th>
-          <th>Reservation Time</th>
-          <th>Reservation Status</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="performance : ${performances}">
-          <td>
-            <div class="image-wrapper" style="position: relative; width: 100px;">
-              <img th:src="@{{url}(url=${performance.getUrl()})}"
-                   alt="no image"
-                   style="width: 100px; height: auto; object-fit: cover;"/>
+  <div class="performance-table">
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <th>Image</th>
+        <th>Title</th>
+        <th>Category</th>
+        <th>Place</th>
+        <th>Start Time</th>
+        <th>End Time</th>
+        <th>Reservation Time</th>
+        <th>Reservation Status</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="performance : ${performances}">
+        <td>
+          <div class="image-wrapper" style="position: relative; width: 100px;">
+            <img th:src="@{{url}(url=${performance.getUrl()})}"
+                 alt="no image"
+                 style="width: 100px; height: auto; object-fit: cover;"/>
 
-              <button class="like-button btn btn-sm btn-danger"
-                      style="position: absolute; bottom: 5px; right: 5px;"
-                      th:data-id="${performance.id}"
-                      th:text="${likedPerformanceIds.contains(performance.id)} ? '♥' : '♡'">
-              </button>
-            </div>
-          </td>
-          <td th:text="${performance.title}"></td>
-          <td th:text="${performance.category}"></td>
-          <td th:text="${performance.place}"></td>
-          <td th:text="${#temporals.format(performance.startTime, 'yyyy-MM-dd HH:mm')}"></td>
-          <td th:text="${#temporals.format(performance.endTime, 'yyyy-MM-dd HH:mm')}"></td>
-          <td th:text="${#temporals.format(performance.reservationStartTime, 'yyyy-MM-dd HH:mm')}"></td>
-          <td th:text="${performance.performanceStatus} ? '예매 가능' : '예매 불가'"></td>
-        </tr>
-        </tbody>
-      </table>
-    </div>
+            <button class="like-button btn btn-sm btn-danger"
+                    style="position: absolute; bottom: 5px; right: 5px;"
+                    th:data-id="${performance.id}"
+                    th:text="${likedPerformanceIds.contains(performance.id)} ? '♥' : '♡'">
+            </button>
+          </div>
+        </td>
+        <td th:text="${performance.title}"></td>
+        <td th:text="${performance.category}"></td>
+        <td th:text="${performance.place}"></td>
+        <td th:text="${#temporals.format(performance.startTime, 'yyyy-MM-dd HH:mm')}"></td>
+        <td th:text="${#temporals.format(performance.endTime, 'yyyy-MM-dd HH:mm')}"></td>
+        <td th:text="${#temporals.format(performance.reservationStartTime, 'yyyy-MM-dd HH:mm')}"></td>
+        <td th:text="${performance.performanceStatus} ? '예매 가능' : '예매 불가'"></td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
 
-    <div class="pagination-container" th:if="${totalPage > 1}">
-      <div style="display: flex; gap: 6px; flex-wrap: wrap; min-height: 40px;">
-        <a th:href="@{|/performances${baseQuery}&page=0|}"
-           th:style="${currentPage > 0} ? 'visibility: visible;' : 'visibility: hidden;'"
-           class="custom-pagination">&laquo;</a>
+  <div class="pagination-container" th:if="${totalPage > 1}">
+    <div style="display: flex; gap: 6px; flex-wrap: wrap; min-height: 40px;">
+      <a th:href="@{|/performances${baseQuery}&page=0|}"
+         th:style="${currentPage > 0} ? 'visibility: visible;' : 'visibility: hidden;'"
+         class="custom-pagination">&laquo;</a>
 
-        <a th:href="@{|/performances${baseQuery}&page=${currentPage - 1}|}"
-           th:style="${currentPage > 0} ? 'visibility: visible;' : 'visibility: hidden;'"
-           class="custom-pagination">&lt;</a>
+      <a th:href="@{|/performances${baseQuery}&page=${currentPage - 1}|}"
+         th:style="${currentPage > 0} ? 'visibility: visible;' : 'visibility: hidden;'"
+         class="custom-pagination">&lt;</a>
 
-        <a th:each="i : ${#numbers.sequence(
+      <a th:each="i : ${#numbers.sequence(
             currentPage <= 2 ? 0 : (currentPage + 2 >= totalPage ? totalPage - 5 : currentPage - 2),
             currentPage <= 2 ? (totalPage < 5 ? totalPage - 1 : 4) : (currentPage + 2 >= totalPage ? totalPage - 1 : currentPage + 2))}"
-           th:href="@{|/performances${baseQuery}&page=${i}|}"
-           th:text="${i + 1}"
-           th:classappend="${i == currentPage} ? ' button' : ''"
-           class="custom-pagination"></a>
+         th:href="@{|/performances${baseQuery}&page=${i}|}"
+         th:text="${i + 1}"
+         th:classappend="${i == currentPage} ? ' button' : ''"
+         class="custom-pagination"></a>
 
-        <a th:href="@{|/performances${baseQuery}&page=${currentPage + 1}|}"
-           th:style="${currentPage < totalPage - 1} ? 'visibility: visible;' : 'visibility: hidden;'"
-           class="custom-pagination">&gt;</a>
+      <a th:href="@{|/performances${baseQuery}&page=${currentPage + 1}|}"
+         th:style="${currentPage < totalPage - 1} ? 'visibility: visible;' : 'visibility: hidden;'"
+         class="custom-pagination">&gt;</a>
 
-        <a th:href="@{|/performances${baseQuery}&page=${totalPage - 1}|}"
-           th:style="${currentPage < totalPage - 1} ? 'visibility: visible;' : 'visibility: hidden;'"
-           class="custom-pagination">&raquo;</a>
-      </div>
+      <a th:href="@{|/performances${baseQuery}&page=${totalPage - 1}|}"
+         th:style="${currentPage < totalPage - 1} ? 'visibility: visible;' : 'visibility: hidden;'"
+         class="custom-pagination">&raquo;</a>
     </div>
   </div>
+</div>
 </div>
 
 <div class="modal fade" id="customDateModal" tabindex="-1" role="dialog"
@@ -237,8 +237,6 @@
 <script>
   $("input[name='filter']").on("change", function () {
     const selected = $(this).val();
-    $("#categorySelect").hide();
-
     if (selected === "custom") {
       $('#customDateModal').modal('show');
     } else if (selected === "category") {

--- a/src/main/resources/templates/performance/view_performances.html
+++ b/src/main/resources/templates/performance/view_performances.html
@@ -98,7 +98,7 @@
         <div class="form-check form-check-inline">
           <input class="form-check-input" type="radio" name="filter" id="category" value="category">
           <label class="form-check-label" for="category">카테고리</label>
-          <select id="categorySelect" class="ml-2" style="display: none;">
+          <select id="categorySelect" class="ml-2" style="display: inline;">
             <option th:each="category : ${categories}" th:value="${category}" th:text="${category}">
               선택
             </option>

--- a/src/main/resources/templates/performance/view_performances.html
+++ b/src/main/resources/templates/performance/view_performances.html
@@ -84,8 +84,17 @@
 <div class="container mt-4">
   <h1 class="text-center mb-4">공연 목록 조회</h1>
   <div class="content-box">
-    <div class="filter-form-container">
-      <form id="filterForm" class="mb-4">
+    <form method="get" action="/performances" class="form-inline">
+      <div class="form-group mb-2 mr-2">
+        <label for="searchInput" class="sr-only">검색</label>
+        <input type="text" id="searchInput" name="search" class="form-control"
+               placeholder="공연 제목으로 검색"
+               th:value="${param.search}"/>
+      </div>
+      <button type="submit" class="btn btn-primary mb-2">검색</button>
+    </form>
+    <form id="filterForm" class="mb-4">
+      <div class="filter-form-container">
         <div class="form-check form-check-inline">
           <input class="form-check-input" type="radio" name="filter" id="latest" value="latest"
                  checked>


### PR DESCRIPTION
## ✨ 설명
- #107 
- 공연 제목에 포함된 키워드로 검색
- 카테고리 필터링 부분에서 select display 속성값 변경
    - 기본 option 값 지정
#### 1. (작업 파일)
PerformanceController
PerformanceService
PerformanceRepsitory
view_performances.html

#### 2. (작업 내용 요약)
- 공연 제목에 포함된 키워드로 검색 기능 구현
    - 검색창에 공백이나 아무것도 입력하지 않았을 때, 최신순으로 조회하도록 처리
 - select display 속성값을 none -> inline으로 변경
![image](https://github.com/user-attachments/assets/9e9487b0-64cd-4a4e-9fe4-7e9fb833f5ec)
![image](https://github.com/user-attachments/assets/09e71a65-774f-4801-9d31-14326ef70d09)
![image](https://github.com/user-attachments/assets/b905d4a1-327e-4dcb-b1a1-e90d55853dfa)

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- 추후에 ElasticSearch 같은 검색 엔진을 도입하면 키워드 검색 성능이 향상될 것이라 생각합니다 !

<br/>
