### PR TITLE
[feat] : 로그인 성공 헨들러 로직 추가

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/user/service/handler/FormLoginSuccessHandler.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/service/handler/FormLoginSuccessHandler.java
@@ -10,11 +10,15 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class FormLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -26,6 +30,12 @@ public class FormLoginSuccessHandler implements AuthenticationSuccessHandler {
         session.setAttribute("loginUser",
             new SessionUser(userDetails.getId(), userDetails.getName()));
 
-        response.sendRedirect("/");
+        SavedRequest savedRequest = requestCache.getRequest(request, response);
+        if (savedRequest != null) {
+            String targetUrl = savedRequest.getRedirectUrl();
+            response.sendRedirect(targetUrl);
+        } else {
+            response.sendRedirect("/");
+        }
     }
 }

--- a/src/main/java/com/fifo/ticketing/domain/user/service/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/fifo/ticketing/domain/user/service/handler/OAuth2LoginSuccessHandler.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Component;
 public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final UserRepository userRepository;
+    private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -29,7 +32,12 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         request.getSession()
             .setAttribute("loginUser", new SessionUser(user.getId(), user.getUsername()));
 
-        response.sendRedirect("/");
-
+        SavedRequest savedRequest = requestCache.getRequest(request, response);
+        if (savedRequest != null) {
+            String targetUrl = savedRequest.getRedirectUrl();
+            response.sendRedirect(targetUrl);
+        } else {
+            response.sendRedirect("/");
+        }
     }
 }


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#124 

#### 1. (작업 파일)

domain/user/service/handler/FormLoginSuccessHandler.java
domain/user/service/handler/OAuth2LoginSuccessHandler.java

#### 2. (작업 내용 요약)

![image](https://github.com/user-attachments/assets/ecc41579-9f3b-4e22-bfe6-842ad8089d48)
위의 코드와 같이 RequestCache를 통해 로그인 이전 상태에서 접속한 url 정보를 활용을 하게 됩니다.

따라서 로그인이 진행되지 않은 상태로 예를 들어 http://localhost:8080/admin/performances 로 접속을 시도시
인증 및 인가가 되지 않았기에 로그인 페이지로 이동하게 됩니다.

그 후 로그인을 성공적으로 진행시 해당 로직이 호출되며 home으로 가는 것이 아닌 http://localhost:8080/admin/performances?continue 로 이동하게 됩니다.

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- (리뷰 받고 싶거나 알리고 싶은 내용)

<br/>
