### PR TITLE
[infra]: Springdoc OpenAPI 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
[[infra] Springdoc OpenAPI 도입](https://github.com/prgrms-be-devcourse/NBE5-7-2-Team01/issues/131) #131 

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

- API 명세서 작성을 용이하게 하기 위해서, Swagger UI가 통합되어 있는 `Springdoc OpenAPI`를 도입하였습니다.
- Spring Boot 3.x 이후의 버전부터는 Springdoc OpenAPI를 사용하는 것이 권장된다는 것을 확인하였습니다.

#### 1. (작업 파일)

- build.gradle
- application.yml

#### 2. (작업 내용 요약)

- application.yml에 이하의 설정을 추가하였습니다.
```
springdoc:
  api-docs:
    enabled: true
    path: /v3/api-docs
    groups:
      enabled: true

  swagger-ui:
    enabled: true
    path: /swagger-ui.html
    operations-sorter: method
    tags-sorter: alpha
    display-request-duration: true
    doc-expansion: none
    persist-authorization: true
    default-models-expand-depth: -1
  paths-to-match:
    - /api/** # /api로 시작하는 모든 경로를 포함합니다.
    - /admin/** # /admin으로 시작하는 모든 경로를 포함합니다.
  cache:
    disabled: true
  show-actuator: false
```

- build.gradle이 수정되었기 때문에 Gradle 의존성을 새로고침해주세요.

- http://localhost:8080/swagger-ui/index.html에 접속하여서 `Swagger UI`가 정상 표시되는 것을 확인합니다.

<img width="1381" alt="스크린샷 2025-05-19 00 06 22" src="https://github.com/user-attachments/assets/23b830e8-dfcb-4e96-8689-a3cc739ec9c1" />

<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- 현재는 admin과 api에 대해서만 Swagger UI를 통해서 확인할 수 있습니다.
- API와 VIEW를 분리하는 작업을 수행하거나, application.yml을 통해서 경로를 추가해 줄 필요가 있습니다.
- 개인적으로는 Api와 View의 경로를 명확히 분리하는게 좋다고 생각하는데, 어떻게 생각하실까요?


<br/>
