### PR TITLE
[feat] 특정 공연의 예매 목록 조회 (관리자) & 예매 상세조회 (관리자)

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/book/controller/api/BookAdminApiController.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/controller/api/BookAdminApiController.java
@@ -1,0 +1,23 @@
+package com.fifo.ticketing.domain.book.controller.api;
+
+import com.fifo.ticketing.domain.book.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/performances/book")
+@RequiredArgsConstructor
+public class BookAdminApiController {
+
+    private final BookService bookService;
+
+    @PostMapping("/cancel/{bookId}")
+    public ResponseEntity<?> cancelPerformance(@PathVariable Long bookId) {
+        bookService.cancelBookByAdmin(bookId);
+        return ResponseEntity.ok("예약이 취소되었습니다.");
+    }
+}

--- a/src/main/java/com/fifo/ticketing/domain/book/dto/BookAdminDetailDto.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/dto/BookAdminDetailDto.java
@@ -1,0 +1,8 @@
+package com.fifo.ticketing.domain.book.dto;
+
+public record BookAdminDetailDto(Long id,
+                                 String username,
+                                 Integer totalPrice,
+                                 Integer quantity) {
+
+}

--- a/src/main/java/com/fifo/ticketing/domain/book/dto/BookUserDetailDto.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/dto/BookUserDetailDto.java
@@ -1,0 +1,28 @@
+package com.fifo.ticketing.domain.book.dto;
+
+import com.fifo.ticketing.domain.book.entity.BookStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@RequiredArgsConstructor
+public class BookUserDetailDto {
+
+    private final Long bookId; //bookId
+    private final Long performanceId;
+    private final String title;
+    private final Integer totalPrice;
+    private final Integer quantity;
+    private final String username;
+    private final String encodedFileName;
+    private final BookStatus bookStatus;
+
+    @Setter
+    private String urlPrefix;
+
+    public String getUrl() {
+        return urlPrefix + encodedFileName;
+    }
+
+}

--- a/src/main/java/com/fifo/ticketing/domain/book/repository/BookRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/book/repository/BookRepository.java
@@ -1,12 +1,13 @@
 package com.fifo.ticketing.domain.book.repository;
 
+import com.fifo.ticketing.domain.book.dto.BookAdminDetailDto;
+import com.fifo.ticketing.domain.book.dto.BookUserDetailDto;
 import com.fifo.ticketing.domain.book.entity.Book;
+import com.fifo.ticketing.domain.book.entity.BookStatus;
+import com.fifo.ticketing.domain.performance.entity.Performance;
 import com.fifo.ticketing.domain.user.entity.User;
 import java.util.List;
 import java.util.Optional;
-
-import com.fifo.ticketing.domain.book.entity.BookStatus;
-import com.fifo.ticketing.domain.performance.entity.Performance;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,15 +18,16 @@ import org.springframework.data.repository.query.Param;
 public interface BookRepository extends JpaRepository<Book, Long> {
 
     Page<Book> findAllByUserId(Long userId, Pageable pageable);
+
     Optional<Book> findByUserIdAndId(Long userId, Long bookId);
 
     @Query("SELECT b FROM Book b "
-            + "JOIN FETCH b.user "
-            + "JOIN FETCH b.performance "
-            + "WHERE b.performance = :performance AND b.bookStatus = :bookStatus")
+        + "JOIN FETCH b.user "
+        + "JOIN FETCH b.performance "
+        + "WHERE b.performance = :performance AND b.bookStatus = :bookStatus")
     List<Book> findAllWithUserAndPerformanceByPerformanceAndBookStatus(
-            @Param("performance") Performance performance,
-            @Param("bookStatus") BookStatus bookStatus);
+        @Param("performance") Performance performance,
+        @Param("bookStatus") BookStatus bookStatus);
 
     @Query("SELECT b FROM Book b " +
         "WHERE b.user.id = :userId " +
@@ -62,12 +64,30 @@ public interface BookRepository extends JpaRepository<Book, Long> {
     @Modifying
     @Query("UPDATE Book b SET b.bookStatus = :cancelStatus WHERE b.performance = :performance AND b.bookStatus = :currentStatus")
     void cancelAllByPerformance(@Param("performance") Performance performance,
-            @Param("cancelStatus") BookStatus cancelStatus,
-            @Param("currentStatus") BookStatus currentStatus);
+        @Param("cancelStatus") BookStatus cancelStatus,
+        @Param("currentStatus") BookStatus currentStatus);
 
+    @Query(
+        "SELECT new com.fifo.ticketing.domain.book.dto.BookAdminDetailDto(b.id, u.username, b.totalPrice, b.quantity) "
+            + "FROM Book b "
+            + "JOIN User u on b.user.id = u.id "
+//            + "WHERE b.performance.id = :performanceId AND b.bookStatus IN ('CONFIRMED', 'PAYED')")
+            + "WHERE b.performance.id = :performanceId")
+    Page<BookAdminDetailDto> findAllBookDetailsAdmin(@Param("performanceId") Long id,
+        Pageable pageable);
 
-  
-    boolean existsByUserAndPerformanceAndBookStatus(User user, Performance performance, BookStatus bookStatus);
+    @Query("SELECT new com.fifo.ticketing.domain.book.dto.BookUserDetailDto("
+        + "b.id, p.id, p.title, b.totalPrice, b.quantity, u.username, f.encodedFileName, b.bookStatus) "
+        + "FROM Book b "
+        + "JOIN Performance p ON b.performance.id = p.id "
+        + "JOIN User u ON b.user.id = u.id "
+        + "LEFT JOIN File f ON p.file.id = f.id "
+        + "WHERE b.id = :bookId AND p.id = :performanceId")
+    BookUserDetailDto findBookDetailByBookId(@Param("bookId") Long bookId,
+        @Param("performanceId") Long performanceId);
+
+    boolean existsByUserAndPerformanceAndBookStatus(User user, Performance performance,
+        BookStatus bookStatus);
 
 }
 

--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/view/AdminPerformanceController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/view/AdminPerformanceController.java
@@ -1,7 +1,10 @@
 package com.fifo.ticketing.domain.performance.controller.view;
 
-
+import com.fifo.ticketing.domain.book.dto.BookAdminDetailDto;
 import com.fifo.ticketing.domain.book.dto.BookSeatViewDto;
+import com.fifo.ticketing.domain.book.dto.BookUserDetailDto;
+import com.fifo.ticketing.domain.book.service.BookService;
+import com.fifo.ticketing.domain.performance.dto.AdminPerformanceBookDetailDto;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceDetailResponse;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceResponseDto;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceStaticsDto;
@@ -19,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -34,6 +38,7 @@ public class AdminPerformanceController {
 
     private final AdminPerformanceService adminPerformanceService;
     private final SeatService seatService;
+    private final BookService bookService;
 
     @GetMapping
     public String viewPerformancesForAdmin(
@@ -172,6 +177,26 @@ public class AdminPerformanceController {
         model.addAttribute("currentPage", statics.getNumber());
         model.addAttribute("totalPages", statics.getTotalPages());
         return "admin/chart_admin";
+    }
+
+    @GetMapping("/book/{performanceId}")
+    public String viewAdminPerformanceBookDetail(@PathVariable("performanceId") Long id,
+        @PageableDefault(size = 5) Pageable pageable, Model model) {
+        AdminPerformanceBookDetailDto performanceBookDetail = adminPerformanceService.getPerformanceBookDetail(
+            id);
+        Page<BookAdminDetailDto> bookAdminList = bookService.getBookAdminList(id, pageable);
+        model.addAttribute("performanceBookDetail", performanceBookDetail);
+        model.addAttribute("bookAdminListPage", bookAdminList);
+        return "admin/performance_book_detail_admin";
+    }
+
+    @GetMapping("/book/{performanceId}/{bookId}")
+    public String viewAdminPerformanceBookUserDetail(
+        @PathVariable("performanceId") Long performanceId, @PathVariable("bookId") Long bookId,
+        Model model) {
+        BookUserDetailDto bookUserDetail = bookService.getBookUserDetail(bookId, performanceId);
+        model.addAttribute("bookUserDetail", bookUserDetail);
+        return "admin/performance_book_user_detail_admin";
     }
 
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/dto/AdminPerformanceBookDetailDto.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/dto/AdminPerformanceBookDetailDto.java
@@ -1,0 +1,24 @@
+package com.fifo.ticketing.domain.performance.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@RequiredArgsConstructor
+public class AdminPerformanceBookDetailDto {
+
+    private final Long id;
+    private final String title;
+    private final String encodedFileName;
+    private final Long totalPrice;
+    private final Long totalQuantity;
+
+    @Setter
+    private String urlPrefix;
+
+    public String getUrl() {
+        return urlPrefix + encodedFileName;
+    }
+
+}

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
@@ -1,5 +1,6 @@
 package com.fifo.ticketing.domain.performance.repository;
 
+import com.fifo.ticketing.domain.performance.dto.AdminPerformanceBookDetailDto;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceStaticsDto;
 import com.fifo.ticketing.domain.performance.entity.Category;
 import com.fifo.ticketing.domain.performance.entity.Performance;
@@ -121,4 +122,15 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
         + "WHERE p.performanceStatus = true "
         + "GROUP BY p.id, p.title, pl.totalSeats")
     Page<AdminPerformanceStaticsDto> findPerformanceStatics(Pageable pageable);
+
+    @Query("SELECT new com.fifo.ticketing.domain.performance.dto.AdminPerformanceBookDetailDto("
+        + "p.id, p.title, f.encodedFileName, COALESCE(SUM(b.totalPrice), 0), COALESCE(SUM(b.quantity), 0)) "
+        + "FROM Performance p "
+        + "LEFT JOIN Book b ON b.performance.id = p.id "
+        + "LEFT JOIN File f ON p.file.id = f.id "
+        + "WHERE p.deletedFlag = false AND p.id = :performanceId "
+        + "GROUP BY p.id, p.title, f.encodedFileName")
+    AdminPerformanceBookDetailDto findPerformanceBookDetails(
+        @Param("performanceId") Long performanceId);
+
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/AdminPerformanceService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/AdminPerformanceService.java
@@ -8,9 +8,11 @@ import static com.fifo.ticketing.global.exception.ErrorCode.NOT_FOUND_PLACES;
 import static com.fifo.ticketing.global.exception.ErrorCode.SEAT_CREATE_FAILED;
 
 import com.fifo.ticketing.domain.book.entity.Book;
+import com.fifo.ticketing.domain.book.repository.BookRepository;
 import com.fifo.ticketing.domain.book.service.BookService;
 import com.fifo.ticketing.domain.like.entity.LikeCount;
 import com.fifo.ticketing.domain.like.repository.LikeCountRepository;
+import com.fifo.ticketing.domain.performance.dto.AdminPerformanceBookDetailDto;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceDetailResponse;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceResponseDto;
 import com.fifo.ticketing.domain.performance.dto.AdminPerformanceStaticsDto;
@@ -49,9 +51,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class AdminPerformanceService {
 
-    @Value("${file.url-prefix}")
-    private String urlPrefix;
-
+    private final BookRepository bookRepository;
     private final PlaceRepository placeRepository;
     private final PerformanceRepository performanceRepository;
     private final GradeRepository gradeRepository;
@@ -60,6 +60,8 @@ public class AdminPerformanceService {
     private final LikeCountRepository likeCountRepository;
     private final BookService bookService;
     private final ApplicationEventPublisher eventPublisher;
+    @Value("${file.url-prefix}")
+    private String urlPrefix;
 
     @Transactional(readOnly = true)
     public AdminPerformanceDetailResponse getPerformanceDetailForAdmin(Long performanceId) {
@@ -251,7 +253,6 @@ public class AdminPerformanceService {
             .toList();
     }
 
-
     @Transactional(readOnly = true)
     public Page<AdminPerformanceResponseDto> getPerformancesSortedByLikesForAdmin(
         Pageable pageable) {
@@ -294,4 +295,17 @@ public class AdminPerformanceService {
             return performanceStatics;
         }
     }
+
+    @Transactional(readOnly = true)
+    public AdminPerformanceBookDetailDto getPerformanceBookDetail(Long performanceId) {
+        AdminPerformanceBookDetailDto performanceBookDetailDtoById = performanceRepository.findPerformanceBookDetails(
+            performanceId);
+        if (performanceBookDetailDtoById == null) {
+            throw new ErrorException(NOT_FOUND_PERFORMANCE);
+        } else {
+            performanceBookDetailDtoById.setUrlPrefix(urlPrefix);
+            return performanceBookDetailDtoById;
+        }
+    }
+
 }

--- a/src/main/resources/templates/admin/performance_book_detail_admin.html
+++ b/src/main/resources/templates/admin/performance_book_detail_admin.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>공연 예매 상세</title>
+  <!-- Bootstrap CSS -->
+  <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+  >
+</head>
+<style>
+  tr:hover {
+    background-color: #f1f1f1;
+  }
+</style>
+<body>
+<div class="container my-5">
+  <h2 class="text-center mb-4" th:text="${performanceBookDetail.title}">공연 제목</h2>
+
+  <div class="text-center mb-4">
+    <img th:src="@{${performanceBookDetail.url}}" alt="공연 이미지" class="img-fluid rounded"
+         style="max-width: 300px;">
+  </div>
+
+  <div class="text-center mb-4">
+    <p><strong>총 예매 금액:</strong> <span th:text="${performanceBookDetail.totalPrice}">0</span>원</p>
+    <p><strong>총 예매 수량:</strong> <span th:text="${performanceBookDetail.totalQuantity}">0</span>매
+    </p>
+  </div>
+
+  <div class="book-list">
+    <h4 class="mb-3">예매 목록</h4>
+    <table class="table table-bordered table-hover text-center">
+      <thead class="table-light">
+      <tr>
+        <th>예매 ID</th>
+        <th>사용자</th>
+        <th>총 금액</th>
+        <th>총 예매 수량</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr th:each="book : ${bookAdminListPage.content}"
+          th:onclick="|window.location.href='/admin/performances/book/${performanceBookDetail.id}/${book.id}'|"
+          style="cursor: pointer;">
+        <td th:text="${book.id}">1</td>
+        <td th:text="${book.username}">사용자</td>
+        <td th:text="${book.totalPrice}">0</td>
+        <td th:text="${book.quantity}">0</td>
+      </tr>
+      <tr th:if="${#lists.isEmpty(bookAdminListPage.content)}">
+        <td colspan="4">예매 정보가 없습니다.</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Pagination -->
+  <nav th:if="${bookAdminListPage.totalPages > 1}">
+    <ul class="pagination justify-content-center mt-4">
+      <li class="page-item" th:classappend="${bookAdminListPage.number == 0} ? 'disabled'">
+        <a class="page-link"
+           th:href="@{|/admin/performances/book/${performanceBookDetail.id}?page=${bookAdminListPage.number - 1}&size=5|}">
+          이전
+        </a>
+      </li>
+
+      <li class="page-item"
+          th:each="i : ${#numbers.sequence(0, bookAdminListPage.totalPages - 1)}"
+          th:classappend="${i == bookAdminListPage.number} ? 'active'">
+        <a class="page-link"
+           th:href="@{|/admin/performances/book/${performanceBookDetail.id}?page=${i}&size=5|}"
+           th:text="${i + 1}">1</a>
+      </li>
+
+      <li class="page-item"
+          th:classappend="${bookAdminListPage.number >= bookAdminListPage.totalPages - 1} ? 'disabled'">
+        <a class="page-link"
+           th:href="@{|/admin/performances/book/${performanceBookDetail.id}?page=${bookAdminListPage.number + 1}&size=5|}">
+          다음
+        </a>
+      </li>
+    </ul>
+  </nav>
+</div>
+
+<!-- Bootstrap JS (optional) -->
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/performance_book_user_detail_admin.html
+++ b/src/main/resources/templates/admin/performance_book_user_detail_admin.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>예매 상세 정보</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+        rel="stylesheet">
+</head>
+<body>
+<div class="container my-5">
+  <h2 class="text-center mb-4">예매 상세 정보</h2>
+
+  <div class="row mb-4">
+    <div class="col-md-4 text-center">
+      <img th:src="@{${bookUserDetail.url}}" alt="공연 이미지" class="img-fluid rounded"
+           style="max-width: 300px;">
+    </div>
+    <div class="col-md-8">
+      <table class="table table-bordered">
+        <tbody>
+        <tr>
+          <th scope="row">예매 ID</th>
+          <td th:text="${bookUserDetail.bookId}">1</td>
+        </tr>
+        <tr>
+          <th scope="row">공연 제목</th>
+          <td th:text="${bookUserDetail.title}">공연 제목</td>
+        </tr>
+        <tr>
+          <th scope="row">예매자</th>
+          <td th:text="${bookUserDetail.username}">사용자 이름</td>
+        </tr>
+        <tr>
+          <th scope="row">총 금액</th>
+          <td><span th:text="${bookUserDetail.totalPrice}"></span>원</td>
+        </tr>
+        <tr>
+          <th scope="row">수량</th>
+          <td><span th:text="${bookUserDetail.quantity}"></span>매</td>
+        </tr>
+        <tr>
+          <th scope="row">예매 상태</th>
+          <td th:text="${bookUserDetail.bookStatus}">CONFIRMED</td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="text-center">
+    <a href="javascript:history.back()" class="btn btn-secondary">뒤로가기</a>
+    <button class="btn btn-danger"
+            onclick="cancelBooking()"
+            th:if="${bookUserDetail.bookStatus.name() == 'CONFIRMED' or bookUserDetail.bookStatus.name() == 'PAYED'}">
+      예매 취소
+    </button>
+    <button class="btn btn-secondary" disabled
+            th:if="${bookUserDetail.bookStatus.name() != 'CONFIRMED' and bookUserDetail.bookStatus.name() != 'PAYED'}">
+      취소 불가
+    </button>
+  </div>
+</div>
+
+<script th:inline="javascript">
+  function cancelBooking() {
+    const bookId = /*[[${bookUserDetail.bookId}]]*/ 0;
+    const performanceId = /*[[${bookUserDetail.performanceId}]]*/ 0;
+
+    fetch(`/admin/performances/book/cancel/${bookId}`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'}
+    }).then(response => {
+      if (response.ok) {
+        alert('예약이 취소되었습니다.');
+        window.location.href = `/admin/performances/book/${performanceId}`;
+      } else {
+        alert('예약 취소에 실패했습니다.');
+      }
+    });
+  }
+</script>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>
+

--- a/src/main/resources/templates/admin/view_performances_admin.html
+++ b/src/main/resources/templates/admin/view_performances_admin.html
@@ -74,7 +74,8 @@
         <th class="px-3 py-2 border">End Time</th>
         <th class="px-3 py-2 border">Reservation Time</th>
         <th class="px-3 py-2 border">Reservation Status</th>
-        <th class="px-3 py-2 border"></th>
+        <th class="px-3 py-2 border">수정</th>
+        <th class="px-3 py-2 border">예매 내역</th>
       </tr>
       </thead>
       <tbody>
@@ -102,9 +103,9 @@
              class="bg-tickethub px-2 py-1 rounded text-sm text-white hover:bg-tickethub-dark"
              th:if="${!(param.sort != null and param.sort[0] == 'deleted')}">수정</a>
         </td>
-        <td>
+        <td class="px-2 py-2 border">
           <a th:href="@{/admin/performances/book/{performanceId}(performanceId=${performance.id})}"
-             class="btn btn-warning"
+             class="bg-tickethub px-2 py-1 rounded text-sm text-white hover:bg-tickethub-dark"
              th:if="${!(param.sort != null and param.sort[0] == 'deleted')}">예매 내역 조회</a>
         </td>
       </tr>

--- a/src/main/resources/templates/admin/view_performances_admin.html
+++ b/src/main/resources/templates/admin/view_performances_admin.html
@@ -23,7 +23,8 @@
 <div class="max-w-7xl mx-auto bg-white shadow-xl rounded-xl p-10">
   <h1 class="text-3xl font-bold text-center text-tickethub mb-8">공연 목록 조회 (관리자)</h1>
 
-  <form id="filterForm" action="/admin/performances" class="flex flex-wrap gap-4 items-center justify-end mb-8">
+  <form id="filterForm" action="/admin/performances"
+        class="flex flex-wrap gap-4 items-center justify-end mb-8">
     <label class="flex items-center gap-1">
       <input type="radio" name="filter" id="latest" value="latest"
              th:checked="${((param.sort == null or param.sort[0] == 'latest') and param.startDate == null and param.category == null)}">
@@ -54,8 +55,11 @@
       <input type="radio" name="filter" id="custom" value="custom">
       <span class="text-sm">Custom</span>
     </label>
-    <button type="submit" class="px-4 py-2 bg-tickethub text-white rounded hover:bg-tickethub-dark text-sm">조회</button>
-    <a href="/admin/performances/create" class="px-4 py-2 bg-tickethub text-white rounded hover:bg-tickethub-dark text-sm">등록</a>
+    <button type="submit"
+            class="px-4 py-2 bg-tickethub text-white rounded hover:bg-tickethub-dark text-sm">조회
+    </button>
+    <a href="/admin/performances/create"
+       class="px-4 py-2 bg-tickethub text-white rounded hover:bg-tickethub-dark text-sm">등록</a>
   </form>
 
   <div class="overflow-x-auto">
@@ -76,21 +80,32 @@
       <tbody>
       <tr th:each="performance : ${performances}" class="text-center">
         <td class="px-2 py-2 border">
-          <img th:src="@{{url}(url=${performance.getUrl()})}" alt="no image" class="w-24 h-auto mx-auto"/>
+          <img th:src="@{{url}(url=${performance.getUrl()})}" alt="no image"
+               class="w-24 h-auto mx-auto"/>
         </td>
         <td class="px-2 py-2 border">
-          <a th:href="@{/admin/performances/{performanceId}(performanceId=${performance.id})}" th:text="${performance.title}" class="text-blue-600 hover:underline"></a>
+          <a th:href="@{/admin/performances/{performanceId}(performanceId=${performance.id})}"
+             th:text="${performance.title}" class="text-blue-600 hover:underline"></a>
         </td>
         <td th:text="${performance.category}" class="px-2 py-2 border"></td>
         <td th:text="${performance.place}" class="px-2 py-2 border"></td>
-        <td th:text="${#temporals.format(performance.startTime, 'yyyy-MM-dd HH:mm')}" class="px-2 py-2 border"></td>
-        <td th:text="${#temporals.format(performance.endTime, 'yyyy-MM-dd HH:mm')}" class="px-2 py-2 border"></td>
-        <td th:text="${#temporals.format(performance.reservationStartTime, 'yyyy-MM-dd HH:mm')}" class="px-2 py-2 border"></td>
-        <td th:text="${performance.performanceStatus} ? '예매 가능' : '예매 불가'" class="px-2 py-2 border"></td>
+        <td th:text="${#temporals.format(performance.startTime, 'yyyy-MM-dd HH:mm')}"
+            class="px-2 py-2 border"></td>
+        <td th:text="${#temporals.format(performance.endTime, 'yyyy-MM-dd HH:mm')}"
+            class="px-2 py-2 border"></td>
+        <td th:text="${#temporals.format(performance.reservationStartTime, 'yyyy-MM-dd HH:mm')}"
+            class="px-2 py-2 border"></td>
+        <td th:text="${performance.performanceStatus} ? '예매 가능' : '예매 불가'"
+            class="px-2 py-2 border"></td>
         <td class="px-2 py-2 border">
           <a th:href="@{/admin/performances/update/{performanceId}(performanceId=${performance.id})}"
              class="bg-tickethub px-2 py-1 rounded text-sm text-white hover:bg-tickethub-dark"
              th:if="${!(param.sort != null and param.sort[0] == 'deleted')}">수정</a>
+        </td>
+        <td>
+          <a th:href="@{/admin/performances/book/{performanceId}(performanceId=${performance.id})}"
+             class="btn btn-warning"
+             th:if="${!(param.sort != null and param.sort[0] == 'deleted')}">예매 내역 조회</a>
         </td>
       </tr>
       </tbody>
@@ -98,15 +113,23 @@
   </div>
 
   <div class="mt-6 flex justify-center gap-2" th:if="${totalPage > 1}">
-    <a th:href="@{|/admin/performances${baseQuery}&page=0|}" th:style="${currentPage > 0} ? '' : 'display:none;'" class="px-3 py-1 border rounded">&laquo;</a>
-    <a th:href="@{|/admin/performances${baseQuery}&page=${currentPage - 1}|}" th:style="${currentPage > 0} ? '' : 'display:none;'" class="px-3 py-1 border rounded">&lt;</a>
+    <a th:href="@{|/admin/performances${baseQuery}&page=0|}"
+       th:style="${currentPage > 0} ? '' : 'display:none;'"
+       class="px-3 py-1 border rounded">&laquo;</a>
+    <a th:href="@{|/admin/performances${baseQuery}&page=${currentPage - 1}|}"
+       th:style="${currentPage > 0} ? '' : 'display:none;'"
+       class="px-3 py-1 border rounded">&lt;</a>
     <a th:each="i : ${#numbers.sequence(currentPage <= 2 ? 0 : (currentPage + 2 >= totalPage ? totalPage - 5 : currentPage - 2), currentPage <= 2 ? (totalPage < 5 ? totalPage - 1 : 4) : (currentPage + 2 >= totalPage ? totalPage - 1 : currentPage + 2))}"
        th:href="@{|/admin/performances${baseQuery}&page=${i}|}"
        th:text="${i + 1}"
        th:classappend="${i == currentPage} ? ' bg-tickethub text-white' : ''"
        class="px-3 py-1 border rounded"></a>
-    <a th:href="@{|/admin/performances${baseQuery}&page=${currentPage + 1}|}" th:style="${currentPage < totalPage - 1} ? '' : 'display:none;'" class="px-3 py-1 border rounded">&gt;</a>
-    <a th:href="@{|/admin/performances${baseQuery}&page=${totalPage - 1}|}" th:style="${currentPage < totalPage - 1} ? '' : 'display:none;'" class="px-3 py-1 border rounded">&raquo;</a>
+    <a th:href="@{|/admin/performances${baseQuery}&page=${currentPage + 1}|}"
+       th:style="${currentPage < totalPage - 1} ? '' : 'display:none;'"
+       class="px-3 py-1 border rounded">&gt;</a>
+    <a th:href="@{|/admin/performances${baseQuery}&page=${totalPage - 1}|}"
+       th:style="${currentPage < totalPage - 1} ? '' : 'display:none;'"
+       class="px-3 py-1 border rounded">&raquo;</a>
   </div>
 </div>
 
@@ -114,7 +137,8 @@
   document.querySelectorAll("input[name='filter']").forEach(input => {
     input.addEventListener("change", () => {
       const selected = input.value;
-      document.getElementById("categorySelect").style.display = (selected === "category") ? "inline-block" : "none";
+      document.getElementById("categorySelect").style.display = (selected === "category")
+          ? "inline-block" : "none";
     });
   });
 


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#116 

#### 1. (작업 파일)

domain/book/repository/BookRepository.java
domain/book/service/BookService.java
domain/performance/controller/view/AdminPerformanceController.java
domain/performance/repository/PerformanceRepository.java
domain/performance/service/AdminPerformanceService.java
domain/performance/dto/AdminPerformanceBookDetailDto.java
domain/book/dto/BookUserDetailDto.java
domain/book/dto/BookAdminDetailDto.java
domain/book/controller/api/BookAdminApiController.java

templates/admin/performance_book_user_detail_admin.html
templates/admin/view_performances_admin.html
templates/admin/performance_book_detail_admin.html

#### 2. (작업 내용 요약)
![image](https://github.com/user-attachments/assets/14b810c7-d34c-4bdd-80df-155295cd3128)
우선 관리자가 공연 목록을 조회 시 예매 내역 조회 버튼이 생긴 것을 확인 할 수 있습니다.

![image](https://github.com/user-attachments/assets/9512363c-babc-49f2-a757-e833b271b772)
해당 버튼을 누르게 되면 해당 공연에 대한 사람들의 예매 내역을 볼 수 있습니다.(이때 예약 상태의 경우 모든 상태에 대해서 보여집니다.)

![image](https://github.com/user-attachments/assets/44a6bda2-28b8-4ec7-b4fc-714b2c0f7adc)
그 후 예매 내역을 누르게 되면 위의 화면과 같이 예매 정보가 나오게 됩니다. 만약 예매 상태가 CONFIRMED, PAYED인 경우에는 예매 취소 버튼이 활성화되게 됩니다.
![image](https://github.com/user-attachments/assets/505f3173-40e1-4de1-90ea-d07af1afaff9)
취소를 누르게 되면 해당 예약 상태는 Canceled로 바뀌게 되며 자리 또한 available()을 통해서 바뀌게 설정했습니다.

![image](https://github.com/user-attachments/assets/97e11635-25c9-4842-a994-1bb3af40433a)
이미 예매가 취소된 상태의 예약 내역을 조회시 예매 상태에 CANCELED로 표시가 되며 취소 불가 버튼으로 바뀌게 됩니다.

![image](https://github.com/user-attachments/assets/97c9066d-5a3f-487d-83fa-ac32587f7ea8)
또한 예매 목록의 경우에는 페이지 적용을 통해 5개씩 나오도록 설정을 해두었습니다.


<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- 예매 내역을 취소 하는 경우에는 Book쪽에 더욱 치우쳐 있다고 생각해서 해당 부분 api 디렉토리 파서 작업 진행했는데 현재 구조 괜찮을까요? 다른 부분은 공연과도 연관이 있어서 performanceAdmin 쪽에서 작업 진행했습니다!

<br/>
