### PR TITLE
[fix] 예매 시작 시 공연 활성화

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/dto/PerformanceDetailResponse.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/dto/PerformanceDetailResponse.java
@@ -20,6 +20,7 @@ public class PerformanceDetailResponse {
     private String category;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
+    private LocalDateTime reservationStartTime;
     private boolean performanceStatus;
     private int totalSeats;
     private List<PerformanceSeatGradeDto> seatGrades;

--- a/src/main/java/com/fifo/ticketing/domain/performance/mapper/PerformanceMapper.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/mapper/PerformanceMapper.java
@@ -22,12 +22,18 @@ public class PerformanceMapper {
 
     public static PerformanceDetailResponse toDetailResponseDto(Performance performance,
         List<PerformanceSeatGradeDto> seatGrades, String urlPrefix) {
-        return PerformanceDetailResponse.builder().performanceId(performance.getId())
-            .title(performance.getTitle()).description(performance.getDescription())
-            .category(performance.getCategory().name()).startTime(performance.getStartTime())
+        return PerformanceDetailResponse.builder()
+            .performanceId(performance.getId())
+            .title(performance.getTitle())
+            .description(performance.getDescription())
+            .category(performance.getCategory().name())
+            .startTime(performance.getStartTime())
             .encodedFileName(performance.getFile().getEncodedFileName())
-            .endTime(performance.getEndTime()).placeName(performance.getPlace().getName())
+            .endTime(performance.getEndTime())
+            .reservationStartTime(performance.getReservationStartTime())
+            .placeName(performance.getPlace().getName())
             .address(performance.getPlace().getAddress())
+            .performanceStatus(performance.isPerformanceStatus())
             .totalSeats(performance.getPlace().getTotalSeats())
             .seatGrades(seatGrades)
             .urlPrefix(urlPrefix)

--- a/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/repository/PerformanceRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -145,4 +146,10 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     )
     Page<Performance> findUpcomingPerformancesByKeywordContainingForAdmin(@Param("now") LocalDateTime now,
             @Param("keyword") String keyword, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Performance p " +
+    "SET p.performanceStatus = true " +
+    "WHERE p.reservationStartTime <= :now AND p.performanceStatus = false ")
+    void updatePerformanceStatusToReservationStart(@Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationOpenService.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/service/PerformanceReservationOpenService.java
@@ -1,0 +1,20 @@
+package com.fifo.ticketing.domain.performance.service;
+
+import com.fifo.ticketing.domain.performance.repository.PerformanceRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceReservationOpenService {
+
+    private final PerformanceRepository performanceRepository;
+
+    @Transactional
+    public void updateStatusIfReservationStart() {
+        performanceRepository.updatePerformanceStatusToReservationStart(LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/fifo/ticketing/global/scheduler/NotificationScheduler.java
@@ -2,6 +2,7 @@ package com.fifo.ticketing.global.scheduler;
 
 
 import com.fifo.ticketing.domain.like.service.LikeMailNotificationService;
+import com.fifo.ticketing.domain.performance.service.PerformanceReservationOpenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class NotificationScheduler {
 
     private final LikeMailNotificationService likeMailNotificationService;
-
+    private final PerformanceReservationOpenService performanceReservationOpenService;
 
     @Scheduled(cron = "0 30 12 * * *")
     public void likeMailNotification() {
@@ -22,5 +23,10 @@ public class NotificationScheduler {
     @Scheduled(cron = "0 0 2 * * *")
     public void NoPayedNotification() {
         likeMailNotificationService.sendNoPayedNotification();
+    }
+
+    @Scheduled(cron = "0 0 13 * * *")
+    public void updatePerformanceStatus() {
+        performanceReservationOpenService.updateStatusIfReservationStart();
     }
 }

--- a/src/main/resources/templates/admin/create_performance.html
+++ b/src/main/resources/templates/admin/create_performance.html
@@ -99,7 +99,7 @@
       endTime: form.endTime.value,
       reservationStartTime: form.reservationStartTime.value,
       category: form.category.value,
-      performanceStatus: form.performanceStatus.value === "true",
+      performanceStatus: form.performanceStatus.value,
       placeId: Number(form.placeId.value),
     };
     const file = form.file.files[0];

--- a/src/main/resources/templates/performance/detail.html
+++ b/src/main/resources/templates/performance/detail.html
@@ -94,9 +94,15 @@
 
   <!-- 오른쪽: 예매 정보 -->
   <div>
-    <button type="button" id="openModalBtn"
+    <button th:if="${performanceDetail.performanceStatus}" type="button" id="openModalBtn"
             class="w-full bg-tickethub text-white py-2 rounded hover:bg-tickethub-dark">좌석 선택
     </button>
+
+    <div th:unless="${performanceDetail.performanceStatus}" class="w-full bg-gray-200 text-gray-700 py-2 px-4 rounded text-center">
+      예매는<br />
+      <span th:text="${#temporals.format(performanceDetail.reservationStartTime, 'yyyy년 MM월 dd일 HH시')}"></span><br />
+      부터 가능합니다.
+    </div>
 
     <div class="mt-6">
       <h3 class="font-semibold mb-2">선택한 좌석</h3>


### PR DESCRIPTION
[//]: # (PR 제목 예시 : [접두사]: 이슈 제목)

## ✨ 설명

<!--
해당 PR에서 어떤 작업을 진행했는지 알려주세요 (코드, 이미지 첨부를 통해 설명해주시면 이해하기 더 쉬울것 같아요!)

-->

#### 1. (작업 파일)

- performance/dto/PerformanceDetailResponse.java
- performance/mapper/PerformanceMapper.java
- performance/repository/PerformanceRepository.java
- performance/service/PerformanceReservationOpenService.java
- global/scheduler/NotificationScheduler.java
- templates/admin/create_performance.html
- templates/performance/detail.html

#### 2. (작업 내용 요약)

```java
    @Modifying
    @Query("UPDATE Performance p " +
    "SET p.performanceStatus = true " +
    "WHERE p.reservationStartTime <= :now AND p.performanceStatus = false ")
    void updatePerformanceStatusToReservationStart(@Param("now") LocalDateTime now);
```
공연 예매 시작 시간이 지나면 performanceStatus를 true로 바꾸는 쿼리 작성하였습니다.

```java
    @Scheduled(cron = "0 0 13 * * *")
    public void updatePerformanceStatus() {
        performanceReservationOpenService.updateStatusIfReservationStart();
    }
```

그리고 해당 쿼리는 매일 13시에 동작하도록 스케줄러 추가해두었습니다.

<br />


![스크린샷 2025-05-20 105240](https://github.com/user-attachments/assets/d9e519f9-1e71-4700-ace5-1a73eaf718d3)

예매 시작 전인 공연은 좌석 선택 버튼 대신 안내 문구가 뜨도록 수정했습니다.



<br/>

## 💬 리뷰

<!--
어느 부분을 중점으로 리뷰해줬으면 하는지 작성해주세요.

-->

- (리뷰 받고 싶거나 알리고 싶은 내용)

<br/>
