### PR TITLE
[fix, refactor] 헤더 추가 후 모달이 생성이 안되는 문제 해결, Apache Commons 메서드 사용하여 리팩토링

### DIFF
--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpSession;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -63,8 +64,8 @@ public class PerformanceController {
     ) {
         Pageable pageable = PageRequest.of(page, size);
 
-        if (keyword == null || keyword.isEmpty()) {
-            viewPerformances(session, page, size, model);
+        if (StringUtils.isBlank(keyword)) {
+            return viewPerformances(session, page, size, model);
         }
 
         return renderPerformanceList(

--- a/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
+++ b/src/main/java/com/fifo/ticketing/domain/performance/controller/view/PerformanceController.java
@@ -97,10 +97,10 @@ public class PerformanceController {
     }
 
     private Page<PerformanceResponseDto> getPerformancesBySort(String sort, Pageable pageable) {
-        return switch (sort) {
-            case "likes" -> performanceService.getPerformancesSortedByLikes(pageable);
-            default -> performanceService.getPerformancesSortedByLatest(pageable);
-        };
+        if (StringUtils.equals(sort, "likes")) {
+            return performanceService.getPerformancesSortedByLikes(pageable);
+        }
+        return performanceService.getPerformancesSortedByLatest(pageable);
     }
 
     @GetMapping(params = {"startDate", "endDate"})

--- a/src/main/resources/templates/performance/view_performances.html
+++ b/src/main/resources/templates/performance/view_performances.html
@@ -26,7 +26,7 @@
     background-color: #c82333;
   }
 
-  .modal-backdrop {
+  .custom-modal-backdrop {
     position: fixed;
     top: 0;
     left: 0;
@@ -36,16 +36,17 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 50;
+    z-index: 1050 !important;
   }
 
-  .modal {
+  .custom-modal {
     background-color: white;
     border-radius: 0.5rem;
     padding: 1.5rem;
     width: 90%;
     max-width: 500px;
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+    z-index: 1060;
   }
 
   .hidden {
@@ -214,8 +215,8 @@
 </div>
 
 <!-- 날짜 범위 선택 모달 -->
-<div id="dateRangeModal" class="modal-backdrop hidden">
-  <div class="modal">
+<div id="dateRangeModal" class="custom-modal-backdrop hidden">
+  <div class="custom-modal">
     <div class="flex justify-between items-center mb-4">
       <h3 class="text-lg font-medium text-gray-900">날짜 선택</h3>
       <button id="closeModal" class="text-gray-400 hover:text-gray-500">


### PR DESCRIPTION
## ✨ 설명
- #164 
- Apache Commons의 StringUtil 메서드를 사용하여 null 처리
- Daisy UI의 modal 속성과 flatpick의 modal 속성 충돌 문제 해결
#### 1. (작업 파일)
- PerformanceController
- view_performances.html

#### 2. (작업 내용 요약)
```java
    if (StringUtils.isBlank(keyword)) {
        return viewPerformances(session, page, size, model);
    }
```
- 기존에는 null과 공백 문자열에 대한 처리를 String의 메서드로 했는데, StringUtils의 메서드를 사용하니 예외처리 작업이 편해졌습니다
```
  .custom-modal-backdrop {
    position: fixed;
    top: 0;
    left: 0;
    display: flex;
    align-items: center;
    justify-content: center;
    z-index: 50;
    z-index: 1050 !important;
  }

  .modal {
  .custom-modal {
    background-color: white;
    border-radius: 0.5rem;
    padding: 1.5rem;
    width: 90%;
    max-width: 500px;
    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
    z-index: 1060;
  }
```
- 헤더 적용 후, 사용자 지정 필터 버튼 클릭 시 날짜 선택 모달이 생성이 안되는 문제가 있었습니다. 해당 문제는 Daisy UI의 modal 속성과 flatpick의 modal 속성이 충돌해서 발생하는 문제였고, 충돌이 발생하는 modal이라는 이름이 아니라 custom-modal이라는 구체적인 이름을 지정해주어 문제를 해결했습니다.


<br/>
